### PR TITLE
Feature: logger

### DIFF
--- a/Source/Networking.swift
+++ b/Source/Networking.swift
@@ -170,10 +170,8 @@ public class Networking {
         print("Error \(error.code): \(error.description)")
         print(" ")
 
-        if let response = response {
-            print("Path: \(response.URL!.absoluteString)")
-            print(" ")
-            print("Response: \(response)")
+        if let request = request {
+            print("Request: \(request)")
             print(" ")
         }
 
@@ -187,8 +185,12 @@ public class Networking {
             print(" ")
         }
 
-        if let request = request {
-            print("Request: \(request)")
+        if let response = response as? NSHTTPURLResponse {
+            print("Response status code: \(response.statusCode)")
+            print(" ")
+            print("Path: \(response.URL!.absoluteString)")
+            print(" ")
+            print("Response: \(response)")
             print(" ")
         }
 

--- a/Source/Networking.swift
+++ b/Source/Networking.swift
@@ -33,7 +33,13 @@ public class Networking {
             let semaphore = dispatch_semaphore_create(0)
             var connectionError: NSError?
             var result: AnyObject?
-            NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: { data, _, error in
+            var returnedResponse: NSURLResponse?
+            var returnedData: NSData?
+
+            NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: { data, response, error in
+                returnedResponse = response
+                returnedData = data
+
                 if let data = data {
                     (result, connectionError) = data.toJSON()
                 } else if let error = error {
@@ -45,6 +51,7 @@ public class Networking {
                 } else {
                     dispatch_async(dispatch_get_main_queue(), {
                         UIApplication.sharedApplication().networkActivityIndicatorVisible = false
+                        self.logError(data: returnedData, request: request, response: returnedResponse, error: connectionError)
                         completion(JSON: result, error: connectionError)
                     })
                 }
@@ -52,6 +59,7 @@ public class Networking {
 
             if NSObject.isUnitTesting() {
                 dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
+                self.logError(data: returnedData, request: request, response: returnedResponse, error: connectionError)
                 completion(JSON: result, error: connectionError)
             }
         }
@@ -102,15 +110,21 @@ public class Networking {
                 var connectionError: NSError?
                 var result: AnyObject?
                 let semaphore = dispatch_semaphore_create(0)
+                var returnedResponse: NSURLResponse?
+                var returnedData: NSData?
 
-                NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: { data, _, error in
+                NSURLSession.sharedSession().dataTaskWithRequest(request, completionHandler: { data, response, error in
+                    returnedResponse = response
                     connectionError = error
+                    returnedData = data
 
                     if let data = data {
                         do {
                             result = try NSJSONSerialization.JSONObjectWithData(data, options: .MutableLeaves)
                         } catch let serializingError as NSError {
-                            connectionError = serializingError
+                            if error == nil {
+                                connectionError = serializingError
+                            }
                         }
                     }
 
@@ -119,6 +133,7 @@ public class Networking {
                     } else {
                         dispatch_async(dispatch_get_main_queue(), {
                             UIApplication.sharedApplication().networkActivityIndicatorVisible = false
+                            self.logError(params, data: returnedData, request: request, response: returnedResponse, error: connectionError)
                             completion(JSON: result, error: connectionError)
                         })
                     }
@@ -126,6 +141,7 @@ public class Networking {
                 
                 if NSObject.isUnitTesting() {
                     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
+                    self.logError(params, data: returnedData, request: request, response: returnedResponse, error: connectionError)
                     completion(JSON: result, error: connectionError)
                 }
             }
@@ -136,9 +152,47 @@ public class Networking {
         stubsInstance.stubbedPOSTResponses[path] = response
     }
 
-    // MARK: - Others
+    // MARK: - Utilities
     
     public func urlForPath(path: String) -> NSURL {
         return NSURL(string: self.baseURL + path)!
+    }
+
+    // MARK: - Logging
+
+    public func logError(params: AnyObject? = nil, data: NSData?, request: NSURLRequest?, response: NSURLResponse?, error: NSError?) {
+        guard let error = error else { return }
+
+        print(" ")
+        print("========== Networking Error ==========")
+        print(" ")
+
+        print("Error \(error.code): \(error.description)")
+        print(" ")
+
+        if let response = response {
+            print("Path: \(response.URL!.absoluteString)")
+            print(" ")
+            print("Response: \(response)")
+            print(" ")
+        }
+
+        if let params = params {
+            print("Params: \(params)")
+            print(" ")
+        }
+
+        if let data = data, stringData = NSString(data: data, encoding: NSUTF8StringEncoding) {
+            print("Data: \(stringData)")
+            print(" ")
+        }
+
+        if let request = request {
+            print("Request: \(request)")
+            print(" ")
+        }
+
+        print("================= ~ ==================")
+        print(" ")
     }
 }

--- a/Tests/Tests/Tests.swift
+++ b/Tests/Tests/Tests.swift
@@ -23,7 +23,7 @@ class Tests: XCTestCase {
         var success = false
 
         let networking = Networking(baseURL: baseURL)
-        networking.GET("invalidpath", completion: { JSON, error in
+        networking.GET("/invalidpath", completion: { JSON, error in
             if let JSON: AnyObject = JSON {
                 fatalError("JSON not nil: \(JSON)")
             } else {


### PR DESCRIPTION
Logs networking errors

```
========== Networking Error ==========
 
Error 3840: Error Domain=NSCocoaErrorDomain Code=3840 "JSON text did not start with array or object and option to allow fragments not set." UserInfo={NSDebugDescription=JSON text did not start with array or object and option to allow fragments not set.}
 
Path: http://httpbin.org/posdddddt
 
Response: <NSHTTPURLResponse: 0x7f8e19f28920> { URL: http://httpbin.org/posdddddt } { status code: 404, headers {
    "Access-Control-Allow-Credentials" = true;
    "Access-Control-Allow-Origin" = "*";
    Connection = "keep-alive";
    "Content-Length" = 233;
    "Content-Type" = "text/html";
    Date = "Thu, 08 Oct 2015 12:52:58 GMT";
    Server = nginx;
} }
 
Params: {
    password = password;
    username = jameson;
}
 
Data: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>404 Not Found</title>
<h1>Not Found</h1>
<p>The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again.</p>

 
Request: <NSMutableURLRequest: 0x7f8e19f0f8d0> { URL: http://httpbin.org/posdddddt }
 
================= ~ ==================
```