### PR TITLE
Feature: stub failures

### DIFF
--- a/Source/Networking+HTTPRequest.swift
+++ b/Source/Networking+HTTPRequest.swift
@@ -25,8 +25,8 @@ public extension Networking {
      - parameter path: The path for the stubbed GET request.
      - parameter response: An `AnyObject` that will be returned when a GET request is made to the specified path.
      */
-    public func stubGET(path: String, response: AnyObject?, failed: Bool = false) {
-        self.stub(.GET, path: path, response: response, failed: failed)
+    public func stubGET(path: String, response: AnyObject?, statusCode: Int = 200) {
+        self.stub(.GET, path: path, response: response, statusCode: statusCode)
     }
 
     /**
@@ -67,8 +67,8 @@ public extension Networking {
      - parameter path: The path for the stubbed POST request.
      - parameter response: An `AnyObject` that will be returned when a POST request is made to the specified path.
      */
-    public func stubPOST(path: String, response: AnyObject?, failed: Bool = false) {
-        self.stub(.POST, path: path, response: response, failed: failed)
+    public func stubPOST(path: String, response: AnyObject?, statusCode: Int = 200) {
+        self.stub(.POST, path: path, response: response, statusCode: statusCode)
     }
 
     /**
@@ -109,8 +109,8 @@ public extension Networking {
      - parameter path: The path for the stubbed PUT request.
      - parameter response: An `AnyObject` that will be returned when a PUT request is made to the specified path.
      */
-    public func stubPUT(path: String, response: AnyObject?, failed: Bool = false) {
-        self.stub(.PUT, path: path, response: response, failed: failed)
+    public func stubPUT(path: String, response: AnyObject?, statusCode: Int = 200) {
+        self.stub(.PUT, path: path, response: response, statusCode: statusCode)
     }
 
     /**
@@ -150,8 +150,8 @@ public extension Networking {
      - parameter path: The path for the stubbed DELETE request.
      - parameter response: An `AnyObject` that will be returned when a DELETE request is made to the specified path.
      */
-    public func stubDELETE(path: String, response: AnyObject?, failed: Bool = false) {
-        self.stub(.DELETE, path: path, response: response, failed: failed)
+    public func stubDELETE(path: String, response: AnyObject?, statusCode: Int = 200) {
+        self.stub(.DELETE, path: path, response: response, statusCode: statusCode)
     }
 
     /**

--- a/Source/Networking+HTTPRequest.swift
+++ b/Source/Networking+HTTPRequest.swift
@@ -12,18 +12,12 @@ public extension Networking {
     }
 
     /**
-     Cancels the GET request for the specified path. This causes the request to complete with error code -999
-     - parameter path: The path for the cancelled GET request
-     */
-    public func cancelGET(path: String) {
-        self.cancelRequest(.Data, requestType: .GET, path: path)
-    }
-
-    /**
      Stubs GET request for the specified path. After registering this, every GET request to the path, will return
      the registered response.
      - parameter path: The path for the stubbed GET request.
      - parameter response: An `AnyObject` that will be returned when a GET request is made to the specified path.
+     - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the
+     response object will be returned, otherwise we will return an error containig the provided status code.
      */
     public func stubGET(path: String, response: AnyObject?, statusCode: Int = 200) {
         self.stub(.GET, path: path, response: response, statusCode: statusCode)
@@ -38,6 +32,14 @@ public extension Networking {
      */
     public func stubGET(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
         self.stub(.GET, path: path, fileName: fileName, bundle: bundle)
+    }
+
+    /**
+     Cancels the GET request for the specified path. This causes the request to complete with error code -999
+     - parameter path: The path for the cancelled GET request
+     */
+    public func cancelGET(path: String) {
+        self.cancelRequest(.Data, requestType: .GET, path: path)
     }
 }
 
@@ -54,18 +56,12 @@ public extension Networking {
     }
 
     /**
-     Cancels the POST request for the specified path. This causes the request to complete with error code -999
-     - parameter path: The path for the cancelled POST request
-     */
-    public func cancelPOST(path: String) {
-        self.cancelRequest(.Data, requestType: .POST, path: path)
-    }
-
-    /**
      Stubs POST request for the specified path. After registering this, every POST request to the path, will return
      the registered response.
      - parameter path: The path for the stubbed POST request.
      - parameter response: An `AnyObject` that will be returned when a POST request is made to the specified path.
+     - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the
+     response object will be returned, otherwise we will return an error containig the provided status code.
      */
     public func stubPOST(path: String, response: AnyObject?, statusCode: Int = 200) {
         self.stub(.POST, path: path, response: response, statusCode: statusCode)
@@ -80,6 +76,14 @@ public extension Networking {
      */
     public func stubPOST(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
         self.stub(.POST, path: path, fileName: fileName, bundle: bundle)
+    }
+
+    /**
+     Cancels the POST request for the specified path. This causes the request to complete with error code -999
+     - parameter path: The path for the cancelled POST request
+     */
+    public func cancelPOST(path: String) {
+        self.cancelRequest(.Data, requestType: .POST, path: path)
     }
 }
 
@@ -96,18 +100,12 @@ public extension Networking {
     }
 
     /**
-     Cancels the PUT request for the specified path. This causes the request to complete with error code -999
-     - parameter path: The path for the cancelled PUT request
-     */
-    public func cancelPUT(path: String) {
-        self.cancelRequest(.Data, requestType: .PUT, path: path)
-    }
-
-    /**
      Stubs PUT request for the specified path. After registering this, every PUT request to the path, will return
      the registered response.
      - parameter path: The path for the stubbed PUT request.
      - parameter response: An `AnyObject` that will be returned when a PUT request is made to the specified path.
+     - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the
+     response object will be returned, otherwise we will return an error containig the provided status code.
      */
     public func stubPUT(path: String, response: AnyObject?, statusCode: Int = 200) {
         self.stub(.PUT, path: path, response: response, statusCode: statusCode)
@@ -123,6 +121,14 @@ public extension Networking {
     public func stubPUT(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
         self.stub(.PUT, path: path, fileName: fileName, bundle: bundle)
     }
+
+    /**
+     Cancels the PUT request for the specified path. This causes the request to complete with error code -999
+     - parameter path: The path for the cancelled PUT request
+     */
+    public func cancelPUT(path: String) {
+        self.cancelRequest(.Data, requestType: .PUT, path: path)
+    }
 }
 
 // MARK: - DELETE
@@ -137,18 +143,12 @@ public extension Networking {
     }
 
     /**
-     Cancels the DELETE request for the specified path. This causes the request to complete with error code -999
-     - parameter path: The path for the cancelled DELETE request
-     */
-    public func cancelDELETE(path: String) {
-        self.cancelRequest(.Data, requestType: .DELETE, path: path)
-    }
-
-    /**
      Stubs DELETE request for the specified path. After registering this, every DELETE request to the path, will return
      the registered response.
      - parameter path: The path for the stubbed DELETE request.
      - parameter response: An `AnyObject` that will be returned when a DELETE request is made to the specified path.
+     - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the
+     response object will be returned, otherwise we will return an error containig the provided status code.
      */
     public func stubDELETE(path: String, response: AnyObject?, statusCode: Int = 200) {
         self.stub(.DELETE, path: path, response: response, statusCode: statusCode)
@@ -163,5 +163,13 @@ public extension Networking {
      */
     public func stubDELETE(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
         self.stub(.DELETE, path: path, fileName: fileName, bundle: bundle)
+    }
+
+    /**
+     Cancels the DELETE request for the specified path. This causes the request to complete with error code -999
+     - parameter path: The path for the cancelled DELETE request
+     */
+    public func cancelDELETE(path: String) {
+        self.cancelRequest(.Data, requestType: .DELETE, path: path)
     }
 }

--- a/Source/Networking+HTTPRequest.swift
+++ b/Source/Networking+HTTPRequest.swift
@@ -25,8 +25,8 @@ public extension Networking {
      - parameter path: The path for the stubbed GET request.
      - parameter response: An `AnyObject` that will be returned when a GET request is made to the specified path.
      */
-    public func stubGET(path: String, response: AnyObject) {
-        self.stub(.GET, path: path, response: response)
+    public func stubGET(path: String, response: AnyObject?, failed: Bool = false) {
+        self.stub(.GET, path: path, response: response, failed: failed)
     }
 
     /**
@@ -67,8 +67,8 @@ public extension Networking {
      - parameter path: The path for the stubbed POST request.
      - parameter response: An `AnyObject` that will be returned when a POST request is made to the specified path.
      */
-    public func stubPOST(path: String, response: AnyObject) {
-        self.stub(.POST, path: path, response: response)
+    public func stubPOST(path: String, response: AnyObject?, failed: Bool = false) {
+        self.stub(.POST, path: path, response: response, failed: failed)
     }
 
     /**
@@ -109,8 +109,8 @@ public extension Networking {
      - parameter path: The path for the stubbed PUT request.
      - parameter response: An `AnyObject` that will be returned when a PUT request is made to the specified path.
      */
-    public func stubPUT(path: String, response: AnyObject) {
-        self.stub(.PUT, path: path, response: response)
+    public func stubPUT(path: String, response: AnyObject?, failed: Bool = false) {
+        self.stub(.PUT, path: path, response: response, failed: failed)
     }
 
     /**
@@ -150,8 +150,8 @@ public extension Networking {
      - parameter path: The path for the stubbed DELETE request.
      - parameter response: An `AnyObject` that will be returned when a DELETE request is made to the specified path.
      */
-    public func stubDELETE(path: String, response: AnyObject) {
-        self.stub(.DELETE, path: path, response: response)
+    public func stubDELETE(path: String, response: AnyObject?, failed: Bool = false) {
+        self.stub(.DELETE, path: path, response: response, failed: failed)
     }
 
     /**

--- a/Source/Networking+Image.swift
+++ b/Source/Networking+Image.swift
@@ -92,8 +92,8 @@ public extension Networking {
      - parameter path: The path for the stubbed image download.
      - parameter image: A UIImage that will be returned when there's a request to the registered path
      */
-    public func stubImageDownload(path: String, image: UIImage) {
-        self.stub(.GET, path: path, response: image)
+    public func stubImageDownload(path: String, image: UIImage, failed: Bool = false) {
+        self.stub(.GET, path: path, response: image, failed: failed)
     }
 }
 

--- a/Source/Networking+Image.swift
+++ b/Source/Networking+Image.swift
@@ -92,8 +92,8 @@ public extension Networking {
      - parameter path: The path for the stubbed image download.
      - parameter image: A UIImage that will be returned when there's a request to the registered path
      */
-    public func stubImageDownload(path: String, image: UIImage, failed: Bool = false) {
-        self.stub(.GET, path: path, response: image, failed: failed)
+    public func stubImageDownload(path: String, image: UIImage, statusCode: Int = 200) {
+        self.stub(.GET, path: path, response: image, statusCode: statusCode)
     }
 }
 

--- a/Source/Networking.swift
+++ b/Source/Networking.swift
@@ -144,7 +144,7 @@ extension Networking {
     func stub(requestType: RequestType, path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
         do {
             if let result = try JSON.from(fileName, bundle: bundle) {
-                self.stub(requestType, path: path, response: result, failed: false)
+                self.stub(requestType, path: path, response: result, statusCode: 200)
             }
         } catch ParsingError.NotFound {
             fatalError("We couldn't find \(fileName), are you sure is there?")
@@ -153,7 +153,7 @@ extension Networking {
         }
     }
 
-    func stub(requestType: RequestType, path: String, response: AnyObject?, failed: Bool) {
+    func stub(requestType: RequestType, path: String, response: AnyObject?, statusCode: Int) {
         var getStubs = self.stubs[requestType] ?? [String : AnyObject]()
         getStubs[path] = response
         self.stubs[requestType] = getStubs

--- a/Source/Networking.swift
+++ b/Source/Networking.swift
@@ -144,7 +144,7 @@ extension Networking {
     func stub(requestType: RequestType, path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
         do {
             if let result = try JSON.from(fileName, bundle: bundle) {
-                self.stub(requestType, path: path, response: result)
+                self.stub(requestType, path: path, response: result, failed: false)
             }
         } catch ParsingError.NotFound {
             fatalError("We couldn't find \(fileName), are you sure is there?")
@@ -153,7 +153,7 @@ extension Networking {
         }
     }
 
-    func stub(requestType: RequestType, path: String, response: AnyObject) {
+    func stub(requestType: RequestType, path: String, response: AnyObject?, failed: Bool) {
         var getStubs = self.stubs[requestType] ?? [String : AnyObject]()
         getStubs[path] = response
         self.stubs[requestType] = getStubs

--- a/Source/Networking.swift
+++ b/Source/Networking.swift
@@ -4,12 +4,38 @@ import JSON
 import NetworkActivityIndicator
 
 /**
- Categorizes a networking error.
- - `Client:` The 4xx class of status code is intended for cases in which the client seems to have erred.
- - `Server:` Response status codes beginning with the digit "5" indicate cases in which the server is aware that it has erred or is incapable of performing the request.
+ Categorizes a status code.
+ - `Informational`: This class of status code indicates a provisional response, consisting only of the Status-Line and optional headers, and is terminated by an empty line.
+ - `Successful`: This class of status code indicates that the client's request was successfully received, understood, and accepted.
+ - `Redirection`: This class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.
+ - `ClientError:` The 4xx class of status code is intended for cases in which the client seems to have erred.
+ - `ServerError:` Response status codes beginning with the digit "5" indicate cases in which the server is aware that it has erred or is incapable of performing the request.
+ - `Unknown:` This response status code could be used by Foundation for other types of states, for example when a request gets cancelled you will receive status code -999
  */
-public enum NetworkingErrorType {
-    case Client, Server
+public enum NetworkingStatusCodeType {
+    case Informational, Successful, Redirection, ClientError, ServerError, Unknown
+}
+
+public extension Int {
+    /**
+     Categorizes a status code.
+     - returns: The NetworkingStatusCodeType of the status code.
+     */
+    public func statusCodeType() -> NetworkingStatusCodeType {
+        if self >= 100 && self < 200 {
+            return .Informational
+        } else if self >= 200 && self < 300 {
+            return .Successful
+        } else if self >= 300 && self < 400 {
+            return .Redirection
+        } else if self >= 400 && self < 500 {
+            return .ClientError
+        } else if self >= 500 && self < 600 {
+            return .ServerError
+        } else {
+            return .Unknown
+        }
+    }
 }
 
 /**
@@ -22,19 +48,6 @@ public enum NetworkingErrorType {
  */
 public enum NetworkingConfigurationType {
     case Default, Ephemeral, Background
-}
-
-/**
- Categorizes a status code.
- - `Informational`: This class of status code indicates a provisional response, consisting only of the Status-Line and optional headers, and is terminated by an empty line.
- - `Successful`: This class of status code indicates that the client's request was successfully received, understood, and accepted.
- - `Redirection`: This class of status code indicates that further action needs to be taken by the user agent in order to fulfill the request.
- - `ClientError:` The 4xx class of status code is intended for cases in which the client seems to have erred.
- - `ServerError:` Response status codes beginning with the digit "5" indicate cases in which the server is aware that it has erred or is incapable of performing the request.
- - `Unknown:` This response status code could be used by Foundation for other types of states, for example when a request gets cancelled you will receive status code -999
- */
-public enum NetworkingStatusCodeType {
-    case Informational, Successful, Redirection, ClientError, ServerError, Unknown
 }
 
 struct Stub {
@@ -130,25 +143,10 @@ public class Networking {
 
         return destinationURL
     }
-
-    /**
-     Returns the NetworkingErrorType for an NSError
-     - parameter error: The error to be evaluated
-     - returns: A NetworkingErrorType, it can be .Client or .Server
-     */
-    public class func errorTypeForError(error: NSError) -> NetworkingErrorType {
-        if error.code >= 400 && error.code < 500 {
-            return .Client
-        } else {
-            return .Server
-        }
-    }
 }
 
-// MARK: - Private
-
 extension Networking {
-    private func sessionConfiguration() -> NSURLSessionConfiguration {
+    func sessionConfiguration() -> NSURLSessionConfiguration {
         switch self.configurationType {
         case .Default:
             return NSURLSessionConfiguration.defaultSessionConfiguration()
@@ -351,26 +349,7 @@ extension Networking {
                 print(" ")
             }
         }
-
         print("================= ~ ==================")
         print(" ")
-    }
-}
-
-public extension Int {
-    public func statusCodeType() -> NetworkingStatusCodeType {
-        if self >= 100 && self < 200 {
-            return .Informational
-        } else if self >= 200 && self < 300 {
-            return .Successful
-        } else if self >= 300 && self < 400 {
-            return .Redirection
-        } else if self >= 400 && self < 500 {
-            return .ClientError
-        } else if self >= 500 && self < 600 {
-            return .ServerError
-        } else {
-            return .Unknown
-        }
     }
 }

--- a/Tests/HTTPRequestTests.swift
+++ b/Tests/HTTPRequestTests.swift
@@ -27,23 +27,6 @@ extension HTTPRequestTests {
         })
     }
 
-    func testCancelGET() {
-        let expectation = expectationWithDescription("testCancelGET")
-
-        let networking = Networking(baseURL: baseURL)
-        networking.disableTestingMode = true
-        networking.GET("/get", completion: { JSON, error in
-            let canceledCode = error?.code == -999
-            XCTAssertTrue(canceledCode)
-
-            expectation.fulfill()
-        })
-
-        networking.cancelGET("/get")
-
-        waitForExpectationsWithTimeout(3.0, handler: nil)
-    }
-
     func testGETWithInvalidPath() {
         let networking = Networking(baseURL: baseURL)
         networking.GET("/invalidpath", completion: { JSON, error in
@@ -88,6 +71,23 @@ extension HTTPRequestTests {
             let value = entry["title"] as! String
             XCTAssertEqual(value, "Entry 1")
         })
+    }
+
+    func testCancelGET() {
+        let expectation = expectationWithDescription("testCancelGET")
+
+        let networking = Networking(baseURL: baseURL)
+        networking.disableTestingMode = true
+        networking.GET("/get", completion: { JSON, error in
+            let canceledCode = error?.code == -999
+            XCTAssertTrue(canceledCode)
+
+            expectation.fulfill()
+        })
+
+        networking.cancelGET("/get")
+
+        waitForExpectationsWithTimeout(3.0, handler: nil)
     }
 
     func testStatusCodes() {
@@ -148,23 +148,6 @@ extension HTTPRequestTests {
         }
     }
 
-    func testCancelPOST() {
-        let expectation = expectationWithDescription("testCancelPOST")
-
-        let networking = Networking(baseURL: baseURL)
-        networking.disableTestingMode = true
-        networking.POST("/post", parameters: ["username":"jameson", "password":"password"]) { JSON, error in
-            let canceledCode = error?.code == -999
-            XCTAssertTrue(canceledCode)
-
-            expectation.fulfill()
-        }
-
-        networking.cancelPOST("/post")
-
-        waitForExpectationsWithTimeout(3.0, handler: nil)
-    }
-
     func testPOSTWithIvalidPath() {
         let networking = Networking(baseURL: baseURL)
         networking.POST("/posdddddt", parameters: ["username":"jameson", "password":"password"]) { JSON, error in
@@ -194,6 +177,23 @@ extension HTTPRequestTests {
             XCTAssertEqual(401, error!.code)
         })
     }
+
+    func testCancelPOST() {
+        let expectation = expectationWithDescription("testCancelPOST")
+
+        let networking = Networking(baseURL: baseURL)
+        networking.disableTestingMode = true
+        networking.POST("/post", parameters: ["username":"jameson", "password":"password"]) { JSON, error in
+            let canceledCode = error?.code == -999
+            XCTAssertTrue(canceledCode)
+
+            expectation.fulfill()
+        }
+
+        networking.cancelPOST("/post")
+
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+    }
 }
 
 // MARK: PUT
@@ -215,23 +215,6 @@ extension HTTPRequestTests {
             XCTAssertNotNil(JSON!, "JSON not nil")
             XCTAssertNil(error, "Error")
         }
-    }
-
-    func testCancelPUT() {
-        let expectation = expectationWithDescription("testCancelPUT")
-
-        let networking = Networking(baseURL: baseURL)
-        networking.disableTestingMode = true
-        networking.PUT("/put", parameters: ["username":"jameson", "password":"password"]) { JSON, error in
-            let canceledCode = error?.code == -999
-            XCTAssertTrue(canceledCode)
-
-            expectation.fulfill()
-        }
-
-        networking.cancelPUT("/put")
-
-        waitForExpectationsWithTimeout(3.0, handler: nil)
     }
 
     func testPUTWithIvalidPath() {
@@ -263,6 +246,23 @@ extension HTTPRequestTests {
             XCTAssertEqual(401, error!.code)
         })
     }
+
+    func testCancelPUT() {
+        let expectation = expectationWithDescription("testCancelPUT")
+
+        let networking = Networking(baseURL: baseURL)
+        networking.disableTestingMode = true
+        networking.PUT("/put", parameters: ["username":"jameson", "password":"password"]) { JSON, error in
+            let canceledCode = error?.code == -999
+            XCTAssertTrue(canceledCode)
+
+            expectation.fulfill()
+        }
+
+        networking.cancelPUT("/put")
+
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+    }
 }
 
 // MARK: DELETE
@@ -285,23 +285,6 @@ extension HTTPRequestTests {
             let url = JSON["url"] as! String
             XCTAssertEqual(url, "http://httpbin.org/delete")
         })
-    }
-
-    func testCancelDELETE() {
-        let expectation = expectationWithDescription("testCancelDELETE")
-
-        let networking = Networking(baseURL: baseURL)
-        networking.disableTestingMode = true
-        networking.DELETE("/delete", completion: { JSON, error in
-            let canceledCode = error?.code == -999
-            XCTAssertTrue(canceledCode)
-
-            expectation.fulfill()
-        })
-
-        networking.cancelDELETE("/delete")
-
-        waitForExpectationsWithTimeout(3.0, handler: nil)
     }
 
     func testDELETEWithInvalidPath() {
@@ -348,5 +331,22 @@ extension HTTPRequestTests {
             let value = entry["title"] as! String
             XCTAssertEqual(value, "Entry 1")
         })
+    }
+
+    func testCancelDELETE() {
+        let expectation = expectationWithDescription("testCancelDELETE")
+
+        let networking = Networking(baseURL: baseURL)
+        networking.disableTestingMode = true
+        networking.DELETE("/delete", completion: { JSON, error in
+            let canceledCode = error?.code == -999
+            XCTAssertTrue(canceledCode)
+
+            expectation.fulfill()
+        })
+
+        networking.cancelDELETE("/delete")
+
+        waitForExpectationsWithTimeout(3.0, handler: nil)
     }
 }

--- a/Tests/HTTPRequestTests.swift
+++ b/Tests/HTTPRequestTests.swift
@@ -67,6 +67,16 @@ extension HTTPRequestTests {
         })
     }
 
+    func testGETStubsWithInvalidStatusCode() {
+        let networking = Networking(baseURL: baseURL)
+
+        networking.stubGET("/stories", response: nil, statusCode: 401)
+
+        networking.GET("/stories", completion: { JSON, error in
+            XCTAssertEqual(401, error!.code)
+        })
+    }
+
     func testGETStubsUsingFile() {
         let networking = Networking(baseURL: baseURL)
 

--- a/Tests/HTTPRequestTests.swift
+++ b/Tests/HTTPRequestTests.swift
@@ -184,6 +184,16 @@ extension HTTPRequestTests {
             XCTAssertEqual(value!, "Elvis")
         }
     }
+
+    func testPOSTStubsWithInvalidStatusCode() {
+        let networking = Networking(baseURL: baseURL)
+
+        networking.stubPOST("/story", response: nil, statusCode: 401)
+
+        networking.POST("/story", parameters: nil, completion: { JSON, error in
+            XCTAssertEqual(401, error!.code)
+        })
+    }
 }
 
 // MARK: PUT
@@ -242,6 +252,16 @@ extension HTTPRequestTests {
             let value = JSON[0]["name"]
             XCTAssertEqual(value!, "Elvis")
         }
+    }
+
+    func testPUTStubsWithInvalidStatusCode() {
+        let networking = Networking(baseURL: baseURL)
+
+        networking.stubPUT("/story", response: nil, statusCode: 401)
+
+        networking.PUT("/story", parameters: nil, completion: { JSON, error in
+            XCTAssertEqual(401, error!.code)
+        })
     }
 }
 
@@ -304,6 +324,16 @@ extension HTTPRequestTests {
             let JSON = JSON as! [String : String]
             let value = JSON["name"]
             XCTAssertEqual(value!, "Elvis")
+        })
+    }
+
+    func testDELETEStubsWithInvalidStatusCode() {
+        let networking = Networking(baseURL: baseURL)
+
+        networking.stubDELETE("/story", response: nil, statusCode: 401)
+
+        networking.DELETE("/story", completion: { JSON, error in
+            XCTAssertEqual(401, error!.code)
         })
     }
 

--- a/Tests/ImageTests.swift
+++ b/Tests/ImageTests.swift
@@ -88,5 +88,13 @@ class ImageTests: XCTestCase {
             XCTAssertEqual(pigImageData, imageData)
         }
     }
+
+    func testStubImageDownloadWithInvalidStatusCode() {
+        let networking = Networking(baseURL: baseURL)
+        networking.stubImageDownload("/image/png", image: nil, statusCode: 401)
+        networking.downloadImage("/image/png") { image, error in
+            XCTAssertEqual(401, error!.code)
+        }
+    }
     #endif
 }

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import XCTest
-import Networking
 
 class Tests: XCTestCase {
     let baseURL = "http://httpbin.org"

--- a/Tests/Tests.swift
+++ b/Tests/Tests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import Networking
 
 class Tests: XCTestCase {
     let baseURL = "http://httpbin.org"
@@ -47,5 +48,15 @@ class Tests: XCTestCase {
         let path = "/image/png"
         let destinationURL = networking.destinationURL(path)
         XCTAssertEqual(destinationURL.lastPathComponent!, "http:--httpbin.org-image-png")
+    }
+
+    func testStatusCodeType() {
+        XCTAssertEqual((-999).statusCodeType(), NetworkingStatusCodeType.Unknown)
+        XCTAssertEqual(99.statusCodeType(), NetworkingStatusCodeType.Unknown)
+        XCTAssertEqual(101.statusCodeType(), NetworkingStatusCodeType.Informational)
+        XCTAssertEqual(203.statusCodeType(), NetworkingStatusCodeType.Successful)
+        XCTAssertEqual(303.statusCodeType(), NetworkingStatusCodeType.Redirection)
+        XCTAssertEqual(403.statusCodeType(), NetworkingStatusCodeType.ClientError)
+        XCTAssertEqual(550.statusCodeType(), NetworkingStatusCodeType.ServerError)
     }
 }


### PR DESCRIPTION
Fixes #54

Not only adds the feature of stubbing failures but also adds support for returning custom status codes in the stubbed responses. If the response is different than 2XX it will create a NSError with the error.