### PR TITLE
Rename stub to fake

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - Singleton free
 - Optimized for unit testing
 - Minimal implementation
-- Easy stubbing
+- Easy fake requests (mocking/stubbing)
 - Runs synchronously in automatic testing enviroments
 - Image download and caching
 - Free
@@ -21,7 +21,7 @@
     * [Bearer token](#bearer-token)
 * [Making a request](#making-a-request)
 * [Content Types](#content-types)
-* [Stubbing](#stubbing)
+* [Faking a request](#faking-a-request)
 * [Cancelling](#cancelling)
 * [Image download](#image-download)
 * [Error logging](#error-logging)
@@ -133,39 +133,39 @@ networking.POST("/post", contentType: .FormURLEncoded, parameters: ["custname":"
 }
 ```
 
-## Stubbing
+## Faking a request
 
-Stubbing a request means that after calling this method on a specific path, any call to this resource, will return what you registered as a response. 
+Faking a request means that after calling this method on a specific path, any call to this resource, will return what you registered as a response. This technique is also known as mocking or stubbing.
 
-**Stubbing with successfull response**:
+**Faking with successfull response**:
 
 ```swift
 let networking = Networking(baseURL: "https://api-news.layervault.com/api/v2")
-networking.stubGET("/stories", response: [["id" : 47333, "title" : "Site Design: Aquest"]])
+networking.fakeGET("/stories", response: [["id" : 47333, "title" : "Site Design: Aquest"]])
 networking.GET("/stories", completion: { JSON, error in
     // JSON containing stories
 })
 ```
 
-**Stubbing with contents of a file**:
+**Faking with contents of a file**:
 
 If your file is not located in the main bundle you have to specify using the bundle parameters, otherwise `NSBundle.mainBundle()` will be used.
 
 ```swift
 let networking = Networking(baseURL: baseURL)
-networking.stubGET("/entries", fileName: "entries.json")
+networking.fakeGET("/entries", fileName: "entries.json")
 networking.GET("/entries", completion: { JSON, error in
     // JSON with the contents of entries.json
 })
 ```
 
-**Stubbing with status code**:
+**Faking with status code**:
 
-If you do not provide a status code for this stub, the default returned one will be 200 (SUCCESS), but if you do provide a status code that is not 2XX, then **Networking** will return an NSError containing the status code and a proper error description.
+If you do not provide a status code for this fake request, the default returned one will be 200 (SUCCESS), but if you do provide a status code that is not 2XX, then **Networking** will return an NSError containing the status code and a proper error description.
 
 ```swift
 let networking = Networking(baseURL: "https://api-news.layervault.com/api/v2")
-networking.stubGET("/stories", response: nil, statusCode: 500)
+networking.fakeGET("/stories", response: nil, statusCode: 500)
 networking.GET("/stories", completion: { JSON, error in
     // error with status code 500
 })
@@ -193,14 +193,14 @@ networking.downloadImage("/image/png") { image, error in
 }
 ```
 
-**Stubbing**:
+**Faking**:
 
 ```swift
 let networking = Networking(baseURL: baseURL)
 let pigImage = UIImage(named: "pig.png")!
-networking.stubImageDownload("/image/png", image: pigImage)
+networking.fakeImageDownload("/image/png", image: pigImage)
 networking.downloadImage("/image/png") { image, error in
-   // Here you'll get the stubbed pig.png image
+   // Here you'll get the provided pig.png image
 }
 ```
 

--- a/Source/Networking+HTTPRequest.swift
+++ b/Source/Networking+HTTPRequest.swift
@@ -12,26 +12,26 @@ public extension Networking {
     }
 
     /**
-     Stubs GET request for the specified path. After registering this, every GET request to the path, will return
+     Registers a fake GET request for the specified path. After registering this, every GET request to the path, will return
      the registered response.
-     - parameter path: The path for the stubbed GET request.
+     - parameter path: The path for the faked GET request.
      - parameter response: An `AnyObject` that will be returned when a GET request is made to the specified path.
      - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the
      response object will be returned, otherwise we will return an error containig the provided status code.
      */
-    public func stubGET(path: String, response: AnyObject?, statusCode: Int = 200) {
-        self.stub(.GET, path: path, response: response, statusCode: statusCode)
+    public func fakeGET(path: String, response: AnyObject?, statusCode: Int = 200) {
+        self.fake(.GET, path: path, response: response, statusCode: statusCode)
     }
 
     /**
-     Stubs GET request for the specified path using the contents of a file. After registering this, every GET request to the path, will return
+     Registers a fake GET request for the specified path using the contents of a file. After registering this, every GET request to the path, will return
      the contents of the registered file.
-     - parameter path: The path for the stubbed GET request.
+     - parameter path: The path for the faked GET request.
      - parameter fileName: The name of the file, whose contents will be registered as a reponse.
      - parameter bundle: The NSBundle where the file is located.
      */
-    public func stubGET(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
-        self.stub(.GET, path: path, fileName: fileName, bundle: bundle)
+    public func fakeGET(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
+        self.fake(.GET, path: path, fileName: fileName, bundle: bundle)
     }
 
     /**
@@ -56,26 +56,26 @@ public extension Networking {
     }
 
     /**
-     Stubs POST request for the specified path. After registering this, every POST request to the path, will return
+     Registers a fake POST request for the specified path. After registering this, every POST request to the path, will return
      the registered response.
-     - parameter path: The path for the stubbed POST request.
+     - parameter path: The path for the faked POST request.
      - parameter response: An `AnyObject` that will be returned when a POST request is made to the specified path.
      - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the
      response object will be returned, otherwise we will return an error containig the provided status code.
      */
-    public func stubPOST(path: String, response: AnyObject?, statusCode: Int = 200) {
-        self.stub(.POST, path: path, response: response, statusCode: statusCode)
+    public func fakePOST(path: String, response: AnyObject?, statusCode: Int = 200) {
+        self.fake(.POST, path: path, response: response, statusCode: statusCode)
     }
 
     /**
-     Stubs POST request to the specified path using the contents of a file. After registering this, every POST request to the path, will return
+     Registers a fake POST request to the specified path using the contents of a file. After registering this, every POST request to the path, will return
      the contents of the registered file.
-     - parameter path: The path for the stubbed POST request.
+     - parameter path: The path for the faked POST request.
      - parameter fileName: The name of the file, whose contents will be registered as a reponse.
      - parameter bundle: The NSBundle where the file is located.
      */
-    public func stubPOST(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
-        self.stub(.POST, path: path, fileName: fileName, bundle: bundle)
+    public func fakePOST(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
+        self.fake(.POST, path: path, fileName: fileName, bundle: bundle)
     }
 
     /**
@@ -100,26 +100,26 @@ public extension Networking {
     }
 
     /**
-     Stubs PUT request for the specified path. After registering this, every PUT request to the path, will return
+     Registers a fake PUT request for the specified path. After registering this, every PUT request to the path, will return
      the registered response.
-     - parameter path: The path for the stubbed PUT request.
+     - parameter path: The path for the faked PUT request.
      - parameter response: An `AnyObject` that will be returned when a PUT request is made to the specified path.
      - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the
      response object will be returned, otherwise we will return an error containig the provided status code.
      */
-    public func stubPUT(path: String, response: AnyObject?, statusCode: Int = 200) {
-        self.stub(.PUT, path: path, response: response, statusCode: statusCode)
+    public func fakePUT(path: String, response: AnyObject?, statusCode: Int = 200) {
+        self.fake(.PUT, path: path, response: response, statusCode: statusCode)
     }
 
     /**
-     Stubs PUT request to the specified path using the contents of a file. After registering this, every PUT request to the path, will return
+     Registers a fake PUT request to the specified path using the contents of a file. After registering this, every PUT request to the path, will return
      the contents of the registered file.
-     - parameter path: The path for the stubbed PUT request.
+     - parameter path: The path for the faked PUT request.
      - parameter fileName: The name of the file, whose contents will be registered as a reponse.
      - parameter bundle: The NSBundle where the file is located.
      */
-    public func stubPUT(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
-        self.stub(.PUT, path: path, fileName: fileName, bundle: bundle)
+    public func fakePUT(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
+        self.fake(.PUT, path: path, fileName: fileName, bundle: bundle)
     }
 
     /**
@@ -143,26 +143,26 @@ public extension Networking {
     }
 
     /**
-     Stubs DELETE request for the specified path. After registering this, every DELETE request to the path, will return
+     Registers a fake DELETE request for the specified path. After registering this, every DELETE request to the path, will return
      the registered response.
-     - parameter path: The path for the stubbed DELETE request.
+     - parameter path: The path for the faked DELETE request.
      - parameter response: An `AnyObject` that will be returned when a DELETE request is made to the specified path.
      - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the
      response object will be returned, otherwise we will return an error containig the provided status code.
      */
-    public func stubDELETE(path: String, response: AnyObject?, statusCode: Int = 200) {
-        self.stub(.DELETE, path: path, response: response, statusCode: statusCode)
+    public func fakeDELETE(path: String, response: AnyObject?, statusCode: Int = 200) {
+        self.fake(.DELETE, path: path, response: response, statusCode: statusCode)
     }
 
     /**
-     Stubs PUT request to the specified path using the contents of a file. After registering this, every DELETE request to the path, will return
+     Registers a fake DELETE request to the specified path using the contents of a file. After registering this, every DELETE request to the path, will return
      the contents of the registered file.
-     - parameter path: The path for the stubbed DELETE request.
+     - parameter path: The path for the faked DELETE request.
      - parameter fileName: The name of the file, whose contents will be registered as a reponse.
      - parameter bundle: The NSBundle where the file is located.
      */
-    public func stubDELETE(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
-        self.stub(.DELETE, path: path, fileName: fileName, bundle: bundle)
+    public func fakeDELETE(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
+        self.fake(.DELETE, path: path, fileName: fileName, bundle: bundle)
     }
 
     /**

--- a/Source/Networking+Image.swift
+++ b/Source/Networking+Image.swift
@@ -15,11 +15,11 @@ public extension Networking {
         let destinationURL = self.destinationURL(path)
         guard let filePath = self.destinationURL(path).path else { fatalError("File path not valid") }
 
-        if let getStubs = self.stubs[.GET], stub = getStubs[path] {
-            if stub.statusCode.statusCodeType() == .Successful, let image = stub.response as? UIImage {
+        if let getFakeRequests = self.fakeRequests[.GET], fakeRequest = getFakeRequests[path] {
+            if fakeRequest.statusCode.statusCodeType() == .Successful, let image = fakeRequest.response as? UIImage {
                 completion(image: image, error: nil)
             } else {
-                let error = NSError(domain: Networking.ErrorDomain, code: stub.statusCode, userInfo: [NSLocalizedDescriptionKey : NSHTTPURLResponse.localizedStringForStatusCode(stub.statusCode)])
+                let error = NSError(domain: Networking.ErrorDomain, code: fakeRequest.statusCode, userInfo: [NSLocalizedDescriptionKey : NSHTTPURLResponse.localizedStringForStatusCode(fakeRequest.statusCode)])
                 completion(image: nil, error: error)
             }
         } else if let image = self.imageCache.objectForKey(destinationURL.absoluteString) as? UIImage {
@@ -92,13 +92,13 @@ public extension Networking {
     }
 
     /**
-     Stubs a download image request with an UIImage. After registering this, every download request to the path, will return
+     Registers a fake download image request with an UIImage. After registering this, every download request to the path, will return
      the registered UIImage.
-     - parameter path: The path for the stubbed image download.
+     - parameter path: The path for the faked image download request.
      - parameter image: A UIImage that will be returned when there's a request to the registered path
      */
-    public func stubImageDownload(path: String, image: UIImage?, statusCode: Int = 200) {
-        self.stub(.GET, path: path, response: image, statusCode: statusCode)
+    public func fakeImageDownload(path: String, image: UIImage?, statusCode: Int = 200) {
+        self.fake(.GET, path: path, response: image, statusCode: statusCode)
     }
 }
 

--- a/Tests/HTTPRequestTests.swift
+++ b/Tests/HTTPRequestTests.swift
@@ -38,10 +38,10 @@ extension HTTPRequestTests {
         })
     }
 
-    func testGETStubs() {
+    func testFakeGET() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubGET("/stories", response: ["name" : "Elvis"])
+        networking.fakeGET("/stories", response: ["name" : "Elvis"])
 
         networking.GET("/stories", completion: { JSON, error in
             let JSON = JSON as! [String : String]
@@ -50,20 +50,20 @@ extension HTTPRequestTests {
         })
     }
 
-    func testGETStubsWithInvalidStatusCode() {
+    func testFakeGETWithInvalidStatusCode() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubGET("/stories", response: nil, statusCode: 401)
+        networking.fakeGET("/stories", response: nil, statusCode: 401)
 
         networking.GET("/stories", completion: { JSON, error in
             XCTAssertEqual(401, error!.code)
         })
     }
 
-    func testGETStubsUsingFile() {
+    func testFakeGETUsingFile() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubGET("/entries", fileName: "entries.json", bundle: NSBundle(forClass: self.classForKeyedArchiver!))
+        networking.fakeGET("/entries", fileName: "entries.json", bundle: NSBundle(forClass: self.classForKeyedArchiver!))
 
         networking.GET("/entries", completion: { JSON, error in
             let JSON = JSON as! [[String : AnyObject]]
@@ -156,10 +156,10 @@ extension HTTPRequestTests {
         }
     }
 
-    func testPOSTStubs() {
+    func testFakePOST() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubPOST("/story", response: [["name" : "Elvis"]])
+        networking.fakePOST("/story", response: [["name" : "Elvis"]])
 
         networking.POST("/story", parameters: ["username":"jameson", "password":"password"]) { JSON, error in
             let JSON = JSON as! [[String : String]]
@@ -168,10 +168,10 @@ extension HTTPRequestTests {
         }
     }
 
-    func testPOSTStubsWithInvalidStatusCode() {
+    func testFakePOSTWithInvalidStatusCode() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubPOST("/story", response: nil, statusCode: 401)
+        networking.fakePOST("/story", response: nil, statusCode: 401)
 
         networking.POST("/story", parameters: nil, completion: { JSON, error in
             XCTAssertEqual(401, error!.code)
@@ -225,10 +225,10 @@ extension HTTPRequestTests {
         }
     }
 
-    func testPUTStubs() {
+    func testFakePUT() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubPUT("/story", response: [["name" : "Elvis"]])
+        networking.fakePUT("/story", response: [["name" : "Elvis"]])
 
         networking.PUT("/story", parameters: ["username":"jameson", "password":"password"]) { JSON, error in
             let JSON = JSON as! [[String : String]]
@@ -237,10 +237,10 @@ extension HTTPRequestTests {
         }
     }
 
-    func testPUTStubsWithInvalidStatusCode() {
+    func testFakePUTWithInvalidStatusCode() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubPUT("/story", response: nil, statusCode: 401)
+        networking.fakePUT("/story", response: nil, statusCode: 401)
 
         networking.PUT("/story", parameters: nil, completion: { JSON, error in
             XCTAssertEqual(401, error!.code)
@@ -298,10 +298,10 @@ extension HTTPRequestTests {
         })
     }
 
-    func testDELETEStubs() {
+    func testFakeDELETE() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubDELETE("/stories", response: ["name" : "Elvis"])
+        networking.fakeDELETE("/stories", response: ["name" : "Elvis"])
 
         networking.DELETE("/stories", completion: { JSON, error in
             let JSON = JSON as! [String : String]
@@ -310,20 +310,20 @@ extension HTTPRequestTests {
         })
     }
 
-    func testDELETEStubsWithInvalidStatusCode() {
+    func testFakeDELETEWithInvalidStatusCode() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubDELETE("/story", response: nil, statusCode: 401)
+        networking.fakeDELETE("/story", response: nil, statusCode: 401)
 
         networking.DELETE("/story", completion: { JSON, error in
             XCTAssertEqual(401, error!.code)
         })
     }
 
-    func testDELETEStubsUsingFile() {
+    func testFakeDELETEUsingFile() {
         let networking = Networking(baseURL: baseURL)
 
-        networking.stubDELETE("/entries", fileName: "entries.json", bundle: NSBundle(forClass: self.classForKeyedArchiver!))
+        networking.fakeDELETE("/entries", fileName: "entries.json", bundle: NSBundle(forClass: self.classForKeyedArchiver!))
 
         networking.DELETE("/entries", completion: { JSON, error in
             let JSON = JSON as! [[String : AnyObject]]

--- a/Tests/ImageTests.swift
+++ b/Tests/ImageTests.swift
@@ -77,10 +77,10 @@ class ImageTests: XCTestCase {
         waitForExpectationsWithTimeout(3.0, handler: nil)
     }
 
-    func testStubImageDownload() {
+    func testFakeImageDownload() {
         let networking = Networking(baseURL: baseURL)
         let pigImage = UIImage(named: "pig.png", inBundle: NSBundle(forClass: ImageTests.self), compatibleWithTraitCollection: nil)!
-        networking.stubImageDownload("/image/png", image: pigImage)
+        networking.fakeImageDownload("/image/png", image: pigImage)
         networking.downloadImage("/image/png") { image, error in
             XCTAssertNotNil(image)
             let pigImageData = UIImagePNGRepresentation(pigImage)
@@ -89,9 +89,9 @@ class ImageTests: XCTestCase {
         }
     }
 
-    func testStubImageDownloadWithInvalidStatusCode() {
+    func testFakeImageDownloadWithInvalidStatusCode() {
         let networking = Networking(baseURL: baseURL)
-        networking.stubImageDownload("/image/png", image: nil, statusCode: 401)
+        networking.fakeImageDownload("/image/png", image: nil, statusCode: 401)
         networking.downloadImage("/image/png") { image, error in
             XCTAssertEqual(401, error!.code)
         }


### PR DESCRIPTION
Helps this feature to be more accessible to users that don’t need much introduction into what stubbing or mocking means.
