### PR TITLE
Rename ContentType to ParameterType

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,13 @@ networking.POST("/post", params: ["username":"jameson", "password":"password"]) 
 
 **Networking** by default uses `application/json` as the `Content-Type` and `Accept` headers. If you want to use this content type you don't have to do anything.
 
-You can use other content types by proving the `ContentType` attribute. For example, if you want to use `.FormURLEncoded` internally **Networking** will format your parameters so they use [`Percent-encoding`](https://en.wikipedia.org/wiki/Percent-encoding#The_application.2Fx-www-form-urlencoded_type). No more changes needed.
+The HTTP specification is so unfriendly, you have to know the specifics of it before understanding that content type is really just the parameter type. Anyway, here's hoping this makes it more human friendly.
+
+You can use other content types by proving the `ParameterType` attribute. For example, if you want to use `.FormURLEncoded` internally **Networking** will format your parameters so they use [`Percent-encoding`](https://en.wikipedia.org/wiki/Percent-encoding#The_application.2Fx-www-form-urlencoded_type). No more changes needed.
 
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-networking.POST("/post", parameterType: .FormURLEncoded, parameters: ["custname":"jameson"]) { JSON, error in
+networking.POST("/post", parameterType: .FormURLEncoded, parameters: ["name":"jameson"]) { JSON, error in
    // Successfull post using `application/x-www-form-urlencoded` as `Content-Type`
 }
 ```

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ You can use other content types by proving the `ContentType` attribute. For exam
 
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-networking.POST("/post", contentType: .FormURLEncoded, parameters: ["custname":"jameson"]) { JSON, error in
+networking.POST("/post", parameterType: .FormURLEncoded, parameters: ["custname":"jameson"]) { JSON, error in
    // Successfull post using `application/x-www-form-urlencoded` as `Content-Type`
 }
 ```
@@ -160,7 +160,7 @@ At the moment **Networking** supports three types of `Content-Type` out of the b
 For example:
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-networking.POST("/upload", contentType: .Custom("application/octet-stream"), parameters: imageData) { JSON, error in
+networking.POST("/upload", parameterType: .Custom("application/octet-stream"), parameters: imageData) { JSON, error in
    // Successfull upload using `application/octet-stream` as `Content-Type`
 }
 ```

--- a/Sources/Networking+HTTPRequest.swift
+++ b/Sources/Networking+HTTPRequest.swift
@@ -7,8 +7,8 @@ public extension Networking {
     - parameter path: The path for the GET request.
     - parameter completion: A closure that gets called when the GET request is completed, it contains a `JSON` object and a `NSError`.
     */
-    public func GET(path: String, contentType: ContentType = .JSON, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.request(.GET, path: path, contentType: contentType, parameters: nil, completion: completion)
+    public func GET(path: String, parameterType: ParameterType = .JSON, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
+        self.request(.GET, path: path, parameterType: parameterType, parameters: nil, completion: completion)
     }
 
     /**
@@ -52,8 +52,8 @@ public extension Networking {
     - parameter parameters: The parameters to be used, they will be serialized using NSJSONSerialization.
     - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
     */
-    public func POST(path: String, contentType: ContentType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.request(.POST, path: path, contentType: contentType, parameters: parameters, completion: completion)
+    public func POST(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
+        self.request(.POST, path: path, parameterType: parameterType, parameters: parameters, completion: completion)
     }
 
     /**
@@ -97,8 +97,8 @@ public extension Networking {
     - parameter parameters: The parameters to be used, they will be serialized using NSJSONSerialization.
     - parameter completion: A closure that gets called when the PUT request is completed, it contains a `JSON` object and a `NSError`.
     */
-    public func PUT(path: String, contentType: ContentType = .JSON, parameters: AnyObject?, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.request(.PUT, path: path, contentType: contentType, parameters: parameters, completion: completion)
+    public func PUT(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject?, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
+        self.request(.PUT, path: path, parameterType: parameterType, parameters: parameters, completion: completion)
     }
 
     /**
@@ -142,7 +142,7 @@ public extension Networking {
     - parameter completion: A closure that gets called when the DELETE request is completed, it contains a `JSON` object and a `NSError`.
     */
     public func DELETE(path: String, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.request(.DELETE, path: path, contentType: .JSON, parameters: nil, completion: completion)
+        self.request(.DELETE, path: path, parameterType: .JSON, parameters: nil, completion: completion)
     }
 
     /**

--- a/Tests/HTTPRequestTests.swift
+++ b/Tests/HTTPRequestTests.swift
@@ -147,7 +147,7 @@ extension HTTPRequestTests {
 
     func testPOSTWithFormURLEncoded() {
         let networking = Networking(baseURL: baseURL)
-        networking.POST("/post", contentType: .FormURLEncoded, parameters: ["custname":"jameson"]) { JSON, error in
+        networking.POST("/post", parameterType: .FormURLEncoded, parameters: ["custname":"jameson"]) { JSON, error in
             let JSONResponse = (JSON as! [String : AnyObject])["form"] as! [String : String]
             XCTAssertEqual("jameson", JSONResponse["custname"])
             XCTAssertNotNil(JSON!, "JSON not nil")


### PR DESCRIPTION
The HTTP specification is so unfriendly, you have to know the specifics of it before understanding that content type is really just the parameter type. Anyway, here's hoping this makes it more human friendly.