### PR TITLE
Fix: wrong error return

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -350,11 +350,13 @@ extension Networking {
                 self.dataRequest(requestType, path: path, cacheName: cacheName, parameterType: parameterType, parameters: parameters, responseType: responseType) { data, error in
                     var returnedError = error
                     var returnedResponse: AnyObject?
-                    if let data = data where data.length > 0 {
-                        do {
-                            returnedResponse = try NSJSONSerialization.JSONObjectWithData(data, options: [])
-                        } catch let JSONError as NSError {
-                            returnedError = JSONError
+                    if error == nil {
+                        if let data = data where data.length > 0 {
+                            do {
+                                returnedResponse = try NSJSONSerialization.JSONObjectWithData(data, options: [])
+                            } catch let JSONError as NSError {
+                                returnedError = JSONError
+                            }
                         }
                     }
 

--- a/Tests/HTTPRequestTests.swift
+++ b/Tests/HTTPRequestTests.swift
@@ -42,7 +42,7 @@ extension HTTPRequestTests {
         let networking = Networking(baseURL: baseURL)
         networking.GET("/invalidpath") { JSON, error in
             XCTAssertNil(JSON)
-            XCTAssertNotNil(error)
+            XCTAssertEqual(error?.code, 404)
         }
     }
 


### PR DESCRIPTION
After a Networking error happened it tried to serialize an empty JSON, throwing a Cocoa Serialization error instead of a Networking one.

- Tests have been improved
- A fix has been added in place
