### PR TITLE
Prettify error logging

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -586,7 +586,6 @@ extension Networking {
                 print(" ")
             }
         } else {
-            print(" ")
             print("*** Request ***")
             print(" ")
 
@@ -629,7 +628,6 @@ extension Networking {
             }
 
             if let response = response as? NSHTTPURLResponse {
-                print(" ")
                 print("*** Response ***")
                 print(" ")
 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -581,16 +581,20 @@ extension Networking {
 
         let isCancelled = error.code == -999
         if isCancelled {
-            if let request = request {
-                print("Cancelled request: \(request)")
+            if let request = request, url = request.URL {
+                print("Cancelled request: \(url.absoluteString)")
                 print(" ")
             }
         } else {
+            print(" ")
+            print("*** Request ***")
+            print(" ")
+
             print("Error \(error.code): \(error.description)")
             print(" ")
 
-            if let request = request {
-                print("Request: \(request)")
+            if let request = request, url = request.URL {
+                print("URL: \(url.absoluteString)")
                 print(" ")
             }
 
@@ -600,8 +604,10 @@ extension Networking {
                     do {
                         let data = try NSJSONSerialization.dataWithJSONObject(parameters, options: .PrettyPrinted)
                         let string = String(data: data, encoding: NSUTF8StringEncoding)
-                        print("Parameters: \(string)")
-                        print(" ")
+                        if let string = string {
+                            print("Parameters: \(string)")
+                            print(" ")
+                        }
                     } catch let error as NSError {
                         print("Failed pretty printing parameters: \(parameters), error: \(error)")
                         print(" ")
@@ -615,25 +621,27 @@ extension Networking {
                     break
                 default: break
                 }
-
-                print(" ")
             }
 
-            if let data = data, stringData = NSString(data: data, encoding: NSUTF8StringEncoding) {
+            if let data = data, stringData = String(data: data, encoding: NSUTF8StringEncoding) {
                 print("Data: \(stringData)")
                 print(" ")
             }
 
             if let response = response as? NSHTTPURLResponse {
+                print(" ")
+                print("*** Response ***")
+                print(" ")
+
                 if let headers = request?.allHTTPHeaderFields {
                     print("Headers: \(headers)")
                     print(" ")
                 }
-                print("Response status code: \(response.statusCode) — \(NSHTTPURLResponse.localizedStringForStatusCode(response.statusCode))")
+
+                print("Status code: \(response.statusCode) — \(NSHTTPURLResponse.localizedStringForStatusCode(response.statusCode))")
                 print(" ")
-                print("Path: \(response.URL?.absoluteString)")
-                print(" ")
-                print("Response: \(response)")
+
+                print("Full object: \(response)")
                 print(" ")
             }
         }


### PR DESCRIPTION
Removes some optionals and cleans up the logging.

# Before

```
========== Networking Error ==========
 
Error 404: Error Domain=NetworkingErrorDomain Code=404 "not found" UserInfo={NSLocalizedDescription=not found}
 
Request: <NSMutableURLRequest: 0x10031a250> { URL: http://httpbin.org/posdddddt }
 
Parameters: Optional("{\n  \"password\" : \"secret\",\n  \"username\" : \"jameson\"\n}")
 
 
Data: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>404 Not Found</title>
<h1>Not Found</h1>
<p>The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again.</p>

 
Headers: ["Accept": "application/json", "Content-Type": "application/json"]
 
Response status code: 404 — not found
 
Path: Optional("http://httpbin.org/posdddddt")
 
Response: <NSHTTPURLResponse: 0x100702750> { URL: http://httpbin.org/posdddddt } { status code: 404, headers {
    "Access-Control-Allow-Credentials" = true;
    "Access-Control-Allow-Origin" = "*";
    Connection = "keep-alive";
    "Content-Length" = 233;
    "Content-Type" = "text/html";
    Date = "Tue, 24 May 2016 10:11:15 GMT";
    Server = nginx;
} }
 
================= ~ ==================
```

# After

```
========== Networking Error ==========
 
*** Request ***

Error 404: Error Domain=NetworkingErrorDomain Code=404 "not found" UserInfo={NSLocalizedDescription=not found}

URL: http://httpbin.org/posdddddt
 
Parameters: {
  "password" : "secret",
  "username" : "jameson"
}
 
Data: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>404 Not Found</title>
<h1>Not Found</h1>
<p>The requested URL was not found on the server.  If you entered the URL manually please check your spelling and try again.</p>

*** Response ***
 
Headers: ["Accept": "application/json", "Content-Type": "application/json"]
 
Status code: 404 — not found
 
Full object: <NSHTTPURLResponse: 0x1006173d0> { URL: http://httpbin.org/posdddddt } { status code: 404, headers {
    "Access-Control-Allow-Credentials" = true;
    "Access-Control-Allow-Origin" = "*";
    Connection = "keep-alive";
    "Content-Length" = 233;
    "Content-Type" = "text/html";
    Date = "Tue, 24 May 2016 10:13:31 GMT";
    Server = nginx;
} }
 
================= ~ ==================
```