### PR TITLE
Improve request cancellation with ID

### DIFF
--- a/Sources/Networking+DELETE.swift
+++ b/Sources/Networking+DELETE.swift
@@ -6,10 +6,12 @@ public extension Networking {
     - parameter path: The path for the DELETE request.
     - parameter completion: A closure that gets called when the DELETE request is completed, it contains a `JSON` object and a `NSError`.
     */
-    public func DELETE(path: String, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.request(.DELETE, path: path, parameterType: .JSON, parameters: nil, parts: nil, responseType: .JSON) { JSON, headers, error in
+    public func DELETE(path: String, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
+        let requestID = self.request(.DELETE, path: path, parameterType: .JSON, parameters: nil, parts: nil, responseType: .JSON) { JSON, headers, error in
             completion(JSON: JSON, error: error)
         }
+
+        return requestID
     }
 
     /**
@@ -17,8 +19,10 @@ public extension Networking {
      - parameter path: The path for the DELETE request.
      - parameter completion: A closure that gets called when the DELETE request is completed, it contains a `JSON` object and a `NSError`.
      */
-    public func DELETE(path: String, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) {
-        self.request(.DELETE, path: path, parameterType: .JSON, parameters: nil, parts: nil, responseType: .JSON, completion: completion)
+    public func DELETE(path: String, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) -> String  {
+        let requestID = self.request(.DELETE, path: path, parameterType: .JSON, parameters: nil, parts: nil, responseType: .JSON, completion: completion)
+
+        return requestID
     }
 
     /**
@@ -38,15 +42,16 @@ public extension Networking {
      - parameter bundle: The NSBundle where the file is located.
      */
     public func fakeDELETE(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
-        self.fake(.DELETE, path: path, fileName: fileName, bundle: bundle)
+        self.fake(.DELETE, path: path, fileName: fileName, bundle: bundle)        
     }
 
     /**
      Cancels the DELETE request for the specified path. This causes the request to complete with error code -999.
      - parameter path: The path for the cancelled DELETE request.
+     - parameter completion: A closure that gets called when the cancellation is completed.
      */
-    public func cancelDELETE(path: String) {
+    public func cancelDELETE(path: String, completion: (Void -> Void)? = nil) {
         let url = self.urlForPath(path)
-        self.cancelRequest(.Data, requestType: .DELETE, url: url)
+        self.cancelRequest(.Data, requestType: .DELETE, url: url, completion: completion)
     }
 }

--- a/Sources/Networking+DELETE.swift
+++ b/Sources/Networking+DELETE.swift
@@ -5,6 +5,7 @@ public extension Networking {
     DELETE request to the specified path, using the provided parameters.
     - parameter path: The path for the DELETE request.
     - parameter completion: A closure that gets called when the DELETE request is completed, it contains a `JSON` object and a `NSError`.
+    - returns: The request identifier.
     */
     public func DELETE(path: String, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
         let requestID = self.request(.DELETE, path: path, parameterType: .JSON, parameters: nil, parts: nil, responseType: .JSON) { JSON, headers, error in
@@ -18,6 +19,7 @@ public extension Networking {
      DELETE request to the specified path, using the provided parameters.
      - parameter path: The path for the DELETE request.
      - parameter completion: A closure that gets called when the DELETE request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
      */
     public func DELETE(path: String, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) -> String  {
         let requestID = self.request(.DELETE, path: path, parameterType: .JSON, parameters: nil, parts: nil, responseType: .JSON, completion: completion)

--- a/Sources/Networking+DELETE.swift
+++ b/Sources/Networking+DELETE.swift
@@ -2,11 +2,11 @@ import Foundation
 
 public extension Networking {
     /**
-    DELETE request to the specified path, using the provided parameters.
-    - parameter path: The path for the DELETE request.
-    - parameter completion: A closure that gets called when the DELETE request is completed, it contains a `JSON` object and a `NSError`.
-    - returns: The request identifier.
-    */
+     DELETE request to the specified path, using the provided parameters.
+     - parameter path: The path for the DELETE request.
+     - parameter completion: A closure that gets called when the DELETE request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
+     */
     public func DELETE(path: String, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
         let requestID = self.request(.DELETE, path: path, parameterType: .JSON, parameters: nil, parts: nil, responseType: .JSON) { JSON, headers, error in
             completion(JSON: JSON, error: error)
@@ -44,7 +44,7 @@ public extension Networking {
      - parameter bundle: The NSBundle where the file is located.
      */
     public func fakeDELETE(path: String, fileName: String, bundle: NSBundle = NSBundle.mainBundle()) {
-        self.fake(.DELETE, path: path, fileName: fileName, bundle: bundle)        
+        self.fake(.DELETE, path: path, fileName: fileName, bundle: bundle)
     }
 
     /**

--- a/Sources/Networking+GET.swift
+++ b/Sources/Networking+GET.swift
@@ -6,10 +6,12 @@ public extension Networking {
     - parameter path: The path for the GET request.
     - parameter completion: A closure that gets called when the GET request is completed, it contains a `JSON` object and a `NSError`.
     */
-    public func GET(path: String, parameterType: ParameterType = .JSON, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.request(.GET, path: path, parameterType: parameterType, parameters: nil, parts: nil, responseType: .JSON) { JSON, headers, error in
+    public func GET(path: String, parameterType: ParameterType = .JSON, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String {
+        let requestID = self.request(.GET, path: path, parameterType: parameterType, parameters: nil, parts: nil, responseType: .JSON) { JSON, headers, error in
             completion(JSON: JSON, error: error)
         }
+
+        return requestID
     }
 
     /**
@@ -17,8 +19,10 @@ public extension Networking {
      - parameter path: The path for the GET request.
      - parameter completion: A closure that gets called when the GET request is completed, it contains a `JSON` object and a `NSError`.
      */
-    public func GET(path: String, parameterType: ParameterType = .JSON, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) {
-        self.request(.GET, path: path, parameterType: parameterType, parameters: nil, parts: nil, responseType: .JSON, completion: completion)
+    public func GET(path: String, parameterType: ParameterType = .JSON, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) -> String {
+        let requestID = self.request(.GET, path: path, parameterType: parameterType, parameters: nil, parts: nil, responseType: .JSON, completion: completion)
+
+        return requestID
     }
 
     /**
@@ -44,9 +48,10 @@ public extension Networking {
     /**
      Cancels the GET request for the specified path. This causes the request to complete with error code -999.
      - parameter path: The path for the cancelled GET request
+     - parameter completion: A closure that gets called when the cancellation is completed.
      */
-    public func cancelGET(path: String) {
+    public func cancelGET(path: String, completion: (Void -> Void)? = nil) {
         let url = self.urlForPath(path)
-        self.cancelRequest(.Data, requestType: .GET, url: url)
+        self.cancelRequest(.Data, requestType: .GET, url: url, completion: completion)
     }
 }

--- a/Sources/Networking+GET.swift
+++ b/Sources/Networking+GET.swift
@@ -2,11 +2,11 @@ import Foundation
 
 public extension Networking {
     /**
-    GET request to the specified path.
-    - parameter path: The path for the GET request.
-    - parameter completion: A closure that gets called when the GET request is completed, it contains a `JSON` object and a `NSError`.
-    - returns: The request identifier.
-    */
+     GET request to the specified path.
+     - parameter path: The path for the GET request.
+     - parameter completion: A closure that gets called when the GET request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
+     */
     public func GET(path: String, parameterType: ParameterType = .JSON, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String {
         let requestID = self.request(.GET, path: path, parameterType: parameterType, parameters: nil, parts: nil, responseType: .JSON) { JSON, headers, error in
             completion(JSON: JSON, error: error)

--- a/Sources/Networking+GET.swift
+++ b/Sources/Networking+GET.swift
@@ -5,6 +5,7 @@ public extension Networking {
     GET request to the specified path.
     - parameter path: The path for the GET request.
     - parameter completion: A closure that gets called when the GET request is completed, it contains a `JSON` object and a `NSError`.
+    - returns: The request identifier.
     */
     public func GET(path: String, parameterType: ParameterType = .JSON, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String {
         let requestID = self.request(.GET, path: path, parameterType: parameterType, parameters: nil, parts: nil, responseType: .JSON) { JSON, headers, error in
@@ -18,6 +19,7 @@ public extension Networking {
      GET request to the specified path.
      - parameter path: The path for the GET request.
      - parameter completion: A closure that gets called when the GET request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
      */
     public func GET(path: String, parameterType: ParameterType = .JSON, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) -> String {
         let requestID = self.request(.GET, path: path, parameterType: parameterType, parameters: nil, parts: nil, responseType: .JSON, completion: completion)

--- a/Sources/Networking+Image.swift
+++ b/Sources/Networking+Image.swift
@@ -32,10 +32,11 @@ public extension Networking {
     /**
      Cancels the image download request for the specified path. This causes the request to complete with error code -999.
      - parameter path: The path for the cancelled image download request.
+     - parameter completion: A closure that gets called when the cancellation is completed.
      */
-    public func cancelImageDownload(path: String) {
+    public func cancelImageDownload(path: String, completion: (Void -> Void)? = nil) {
         let url = self.urlForPath(path)
-        self.cancelRequest(.Data, requestType: .GET, url: url)
+        self.cancelRequest(.Data, requestType: .GET, url: url, completion: completion)
     }
 
     /**

--- a/Sources/Networking+POST.swift
+++ b/Sources/Networking+POST.swift
@@ -8,10 +8,12 @@ public extension Networking {
      default this is JSON.
     - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
     */
-    public func POST(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.request(.POST, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON) { JSON, headers, error in
+    public func POST(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
+        let requestID = self.request(.POST, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON) { JSON, headers, error in
             completion(JSON: JSON, error: error)
         }
+
+        return requestID
     }
 
     /**
@@ -21,8 +23,10 @@ public extension Networking {
      default this is JSON.
      - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
      */
-    public func POST(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) {
-        self.request(.POST, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON, completion: completion)
+    public func POST(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) -> String  {
+        let requestID = self.request(.POST, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON, completion: completion)
+
+        return requestID
     }
 
     /**
@@ -33,8 +37,10 @@ public extension Networking {
      - parameter part: The form data that will be sent in the request.
      - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
      */
-    public func POST(path: String, parameters: AnyObject? = nil, part: FormDataPart, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.POST(path, parameters: parameters, parts: [part], completion: completion)
+    public func POST(path: String, parameters: AnyObject? = nil, part: FormDataPart, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
+        let requestID = self.POST(path, parameters: parameters, parts: [part], completion: completion)
+
+        return requestID
     }
 
     /**
@@ -45,10 +51,12 @@ public extension Networking {
      - parameter parts: The list of form data parts that will be sent in the request.
      - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
      */
-    public func POST(path: String, parameters: AnyObject? = nil, parts: [FormDataPart], completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.request(.POST, path: path, parameterType: .MultipartFormData, parameters: parameters, parts: parts, responseType: .JSON) { JSON, headers, error in
+    public func POST(path: String, parameters: AnyObject? = nil, parts: [FormDataPart], completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
+        let requestID = self.request(.POST, path: path, parameterType: .MultipartFormData, parameters: parameters, parts: parts, responseType: .JSON) { JSON, headers, error in
             completion(JSON: JSON, error: error)
         }
+
+        return requestID
     }
 
     /**
@@ -74,9 +82,10 @@ public extension Networking {
     /**
      Cancels the POST request for the specified path. This causes the request to complete with error code -999.
      - parameter path: The path for the cancelled POST request.
+     - parameter completion: A closure that gets called when the cancellation is completed.
      */
-    public func cancelPOST(path: String) {
+    public func cancelPOST(path: String, completion: (Void -> Void)? = nil) {
         let url = self.urlForPath(path)
-        self.cancelRequest(.Data, requestType: .POST, url: url)
+        self.cancelRequest(.Data, requestType: .POST, url: url, completion: completion)
     }
 }

--- a/Sources/Networking+POST.swift
+++ b/Sources/Networking+POST.swift
@@ -2,12 +2,12 @@ import Foundation
 
 public extension Networking {
     /**
-    POST request to the specified path, using the provided parameters.
-    - parameter path: The path for the POST request.
-    - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by 
-     default this is JSON.
-    - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
-    */
+     POST request to the specified path, using the provided parameters.
+     - parameter path: The path for the POST request.
+     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
+     - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
+     */
     public func POST(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
         let requestID = self.request(.POST, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON) { JSON, headers, error in
             completion(JSON: JSON, error: error)
@@ -19,9 +19,9 @@ public extension Networking {
     /**
      POST request to the specified path, using the provided parameters.
      - parameter path: The path for the POST request.
-     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by
-     default this is JSON.
+     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
      - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
      */
     public func POST(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) -> String  {
         let requestID = self.request(.POST, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON, completion: completion)
@@ -32,10 +32,10 @@ public extension Networking {
     /**
      POST request to the specified path, using the provided parameters.
      - parameter path: The path for the POST request.
-     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by
-     default this is JSON.
+     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
      - parameter part: The form data that will be sent in the request.
      - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
      */
     public func POST(path: String, parameters: AnyObject? = nil, part: FormDataPart, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
         let requestID = self.POST(path, parameters: parameters, parts: [part], completion: completion)
@@ -46,10 +46,10 @@ public extension Networking {
     /**
      POST request to the specified path, using the provided parameters.
      - parameter path: The path for the POST request.
-     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by
-     default this is JSON.
+     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
      - parameter parts: The list of form data parts that will be sent in the request.
      - parameter completion: A closure that gets called when the POST request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
      */
     public func POST(path: String, parameters: AnyObject? = nil, parts: [FormDataPart], completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
         let requestID = self.request(.POST, path: path, parameterType: .MultipartFormData, parameters: parameters, parts: parts, responseType: .JSON) { JSON, headers, error in

--- a/Sources/Networking+PUT.swift
+++ b/Sources/Networking+PUT.swift
@@ -2,12 +2,12 @@ import Foundation
 
 public extension Networking {
     /**
-    PUT request to the specified path, using the provided parameters.
-    - parameter path: The path for the PUT request.
-     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by
-     default this is JSON.
-    - parameter completion: A closure that gets called when the PUT request is completed, it contains a `JSON` object and a `NSError`.
-    */
+     PUT request to the specified path, using the provided parameters.
+     - parameter path: The path for the PUT request.
+     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
+     - parameter completion: A closure that gets called when the PUT request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
+     */
     public func PUT(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
         let requestID = self.request(.PUT, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON) { JSON, headers, error in
             completion(JSON: JSON, error: error)
@@ -19,9 +19,9 @@ public extension Networking {
     /**
      PUT request to the specified path, using the provided parameters.
      - parameter path: The path for the PUT request.
-     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by
-     default this is JSON.
+     - parameter parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
      - parameter completion: A closure that gets called when the PUT request is completed, it contains a `JSON` object and a `NSError`.
+     - returns: The request identifier.
      */
     public func PUT(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) -> String  {
         let requestID = self.request(.PUT, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON, completion: completion)

--- a/Sources/Networking+PUT.swift
+++ b/Sources/Networking+PUT.swift
@@ -8,10 +8,12 @@ public extension Networking {
      default this is JSON.
     - parameter completion: A closure that gets called when the PUT request is completed, it contains a `JSON` object and a `NSError`.
     */
-    public func PUT(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, error: NSError?) -> ()) {
-        self.request(.PUT, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON) { JSON, headers, error in
+    public func PUT(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, error: NSError?) -> ()) -> String  {
+        let requestID = self.request(.PUT, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON) { JSON, headers, error in
             completion(JSON: JSON, error: error)
         }
+
+        return requestID
     }
 
     /**
@@ -21,8 +23,10 @@ public extension Networking {
      default this is JSON.
      - parameter completion: A closure that gets called when the PUT request is completed, it contains a `JSON` object and a `NSError`.
      */
-    public func PUT(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) {
-        self.request(.PUT, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON, completion: completion)
+    public func PUT(path: String, parameterType: ParameterType = .JSON, parameters: AnyObject? = nil, completion: (JSON: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) -> String  {
+        let requestID = self.request(.PUT, path: path, parameterType: parameterType, parameters: parameters, parts: nil, responseType: .JSON, completion: completion)
+
+        return requestID
     }
 
     /**
@@ -48,9 +52,10 @@ public extension Networking {
     /**
      Cancels the PUT request for the specified path. This causes the request to complete with error code -999.
      - parameter path: The path for the cancelled PUT request.
+     - parameter completion: A closure that gets called when the cancellation is completed.
      */
-    public func cancelPUT(path: String) {
+    public func cancelPUT(path: String, completion: (Void -> Void)? = nil) {
         let url = self.urlForPath(path)
-        self.cancelRequest(.Data, requestType: .PUT, url: url)
+        self.cancelRequest(.Data, requestType: .PUT, url: url, completion: completion)
     }
 }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -210,7 +210,7 @@ public class Networking {
         if let url = NSURL(string: replacedPath) {
             if let cachesURL = NSFileManager.defaultManager().URLsForDirectory(directory, inDomains: .UserDomainMask).first {
                 #if !os(tvOS)
-                try cachesURL.setResourceValue(true, forKey: NSURLIsExcludedFromBackupKey)
+                    try cachesURL.setResourceValue(true, forKey: NSURLIsExcludedFromBackupKey)
                 #endif
                 let destinationURL = cachesURL.URLByAppendingPathComponent(url.absoluteString)
 
@@ -572,7 +572,7 @@ extension Networking {
                     self.logError(parameterType: parameterType, parameters: parameters, data: returnedData, request: request, response: returnedResponse, error: connectionError)
                     completion(response: returnedData, headers: returnedHeaders, error: connectionError)
                 }
-                }
+            }
 
             session.taskDescription = requestID
             session.resume()

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -129,7 +129,7 @@ public class Networking {
     var disableTestingMode = false
 
     /**
-     The boundary used for multipart requests
+     The boundary used for multipart requests.
      */
     let boundary = String(format: "net.3lvis.networking.%08x%08x", arc4random(), arc4random())
 
@@ -176,7 +176,7 @@ public class Networking {
     /**
      Authenticates using a custom HTTP Authorization header.
      - parameter authorizationHeaderKey: Sets this value as the key for the HTTP `Authorization` header
-     - parameter authorizationHeaderValue: Sets this value to the HTTP `Authorization` header or to the `headerKey` if you provided that
+     - parameter authorizationHeaderValue: Sets this value to the HTTP `Authorization` header or to the `headerKey` if you provided that.
      */
     public func authenticate(headerKey headerKey: String = "Authorization", headerValue: String) {
         self.authorizationHeaderKey = headerKey
@@ -239,6 +239,11 @@ public class Networking {
         return (baseURL, relativePath)
     }
 
+    /**
+     Cancels the request that matches the requestID.
+     - parameter requestID: The ID of the request to be cancelled.
+     - parameter completion: The completion block to be called when the request is cancelled.
+     */
     func cancel(requestID: String, completion: (Void -> Void)? = nil) {
         self.session.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
             var tasks = [NSURLSessionTask]()

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -239,6 +239,24 @@ public class Networking {
         return (baseURL, relativePath)
     }
 
+    func cancel(requestID: String, completion: (Void -> Void)? = nil) {
+        self.session.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
+            var tasks = [NSURLSessionTask]()
+            tasks.appendContentsOf(dataTasks as [NSURLSessionTask])
+            tasks.appendContentsOf(uploadTasks as [NSURLSessionTask])
+            tasks.appendContentsOf(downloadTasks as [NSURLSessionTask])
+
+            for task in tasks {
+                if task.taskDescription == requestID {
+                    task.cancel()
+                    break
+                }
+            }
+
+            completion?()
+        }
+    }
+
     /**
      Cancels all the current requests.
      - parameter completion: The completion block to be called when all the requests are cancelled.
@@ -371,7 +389,9 @@ extension Networking {
         self.fakeRequests[requestType] = fakeRequests
     }
 
-    func request(requestType: RequestType, path: String, cacheName: String? = nil, parameterType: ParameterType?, parameters: AnyObject?, parts: [FormDataPart]?, responseType: ResponseType, completion: (response: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) {
+    func request(requestType: RequestType, path: String, cacheName: String? = nil, parameterType: ParameterType?, parameters: AnyObject?, parts: [FormDataPart]?, responseType: ResponseType, completion: (response: AnyObject?, headers: [String : AnyObject], error: NSError?) -> ()) -> String {
+        var requestID = NSUUID().UUIDString
+
         if let responses = self.fakeRequests[requestType], fakeRequest = responses[path] {
             if fakeRequest.statusCode.statusCodeType() == .Successful {
                 completion(response: fakeRequest.response, headers: [String : AnyObject](), error: nil)
@@ -382,7 +402,7 @@ extension Networking {
         } else {
             switch responseType {
             case .JSON:
-                self.dataRequest(requestType, path: path, cacheName: cacheName, parameterType: parameterType, parameters: parameters, parts: parts, responseType: responseType) { data, headers, error in
+                requestID = self.dataRequest(requestType, path: path, cacheName: cacheName, parameterType: parameterType, parameters: parameters, parts: parts, responseType: responseType) { data, headers, error in
                     var returnedError = error
                     var returnedResponse: AnyObject?
                     if error == nil {
@@ -437,9 +457,12 @@ extension Networking {
                 break
             }
         }
+
+        return requestID
     }
 
-    func dataRequest(requestType: RequestType, path: String, cacheName: String? = nil, parameterType: ParameterType?, parameters: AnyObject?, parts: [FormDataPart]?, responseType: ResponseType, completion: (response: NSData?, headers: [String : AnyObject], error: NSError?) -> ()) {
+    func dataRequest(requestType: RequestType, path: String, cacheName: String? = nil, parameterType: ParameterType?, parameters: AnyObject?, parts: [FormDataPart]?, responseType: ResponseType, completion: (response: NSData?, headers: [String : AnyObject], error: NSError?) -> ()) -> String {
+        let requestID = NSUUID().UUIDString
         let request = NSMutableURLRequest(URL: self.urlForPath(path))
         request.HTTPMethod = requestType.rawValue
 
@@ -515,7 +538,7 @@ extension Networking {
             var returnedData: NSData?
             var returnedHeaders = [String : AnyObject]()
 
-            self.session.dataTaskWithRequest(request) { data, response, error in
+            let session = self.session.dataTaskWithRequest(request) { data, response, error in
                 returnedResponse = response
                 connectionError = error
                 returnedData = data
@@ -544,7 +567,10 @@ extension Networking {
                     self.logError(parameterType: parameterType, parameters: parameters, data: returnedData, request: request, response: returnedResponse, error: connectionError)
                     completion(response: returnedData, headers: returnedHeaders, error: connectionError)
                 }
-                }.resume()
+                }
+
+            session.taskDescription = requestID
+            session.resume()
 
             if TestCheck.isTesting && self.disableTestingMode == false {
                 dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
@@ -552,9 +578,11 @@ extension Networking {
                 completion(response: returnedData, headers: returnedHeaders, error: connectionError)
             }
         }
+
+        return requestID
     }
 
-    func cancelRequest(sessionTaskType: SessionTaskType, requestType: RequestType, url: NSURL) {
+    func cancelRequest(sessionTaskType: SessionTaskType, requestType: RequestType, url: NSURL, completion: (Void -> Void)?) {
         self.session.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
             var sessionTasks = [NSURLSessionTask]()
             switch sessionTaskType {
@@ -572,8 +600,11 @@ extension Networking {
             for sessionTask in sessionTasks {
                 if sessionTask.originalRequest?.HTTPMethod == requestType.rawValue && sessionTask.originalRequest?.URL?.absoluteString == url.absoluteString {
                     sessionTask.cancel()
+                    break
                 }
             }
+
+            completion?()
         }
     }
 

--- a/Sources/TestCheck.swift
+++ b/Sources/TestCheck.swift
@@ -2,9 +2,9 @@ import Foundation
 
 struct TestCheck {
     /**
-    Method to check wheter your on testing mode or not.
-    - returns: A Bool, `true` if you're on testing mode, `false` if you're not.
-    */
+     Method to check wheter your on testing mode or not.
+     - returns: A Bool, `true` if you're on testing mode, `false` if you're not.
+     */
     static let isTesting: Bool = {
         let enviroment = NSProcessInfo.processInfo().environment
         let serviceName = enviroment["XPC_SERVICE_NAME"]

--- a/Tests/DELETETests.swift
+++ b/Tests/DELETETests.swift
@@ -77,17 +77,40 @@ class DELETETests: XCTestCase {
         }
     }
 
-    func testCancelDELETE() {
+    func testCancelDELETEWithPath() {
         let expectation = expectationWithDescription("testCancelDELETE")
 
         let networking = Networking(baseURL: baseURL)
         networking.disableTestingMode = true
+        var completed = false
         networking.DELETE("/delete") { JSON, error in
+            XCTAssertTrue(completed)
             XCTAssertEqual(error?.code, -999)
             expectation.fulfill()
         }
 
-        networking.cancelDELETE("/delete")
+        networking.cancelDELETE("/delete") {
+            completed = true
+        }
+
+        waitForExpectationsWithTimeout(15.0, handler: nil)
+    }
+
+    func testCancelDELETEWithID() {
+        let expectation = expectationWithDescription("testCancelDELETE")
+
+        let networking = Networking(baseURL: baseURL)
+        networking.disableTestingMode = true
+        var completed = false
+        let requestID = networking.DELETE("/delete") { JSON, error in
+            XCTAssertTrue(completed)
+            XCTAssertEqual(error?.code, -999)
+            expectation.fulfill()
+        }
+
+        networking.cancel(requestID) {
+            completed = true
+        }
 
         waitForExpectationsWithTimeout(15.0, handler: nil)
     }

--- a/Tests/GETTests.swift
+++ b/Tests/GETTests.swift
@@ -88,17 +88,40 @@ class GETTests: XCTestCase {
         }
     }
 
-    func testCancelGET() {
+    func testCancelGETWithPath() {
         let expectation = expectationWithDescription("testCancelGET")
 
         let networking = Networking(baseURL: baseURL)
         networking.disableTestingMode = true
+        var completed = false
         networking.GET("/get") { JSON, error in
+            XCTAssertTrue(completed)
             XCTAssertEqual(error?.code, -999)
             expectation.fulfill()
         }
 
-        networking.cancelGET("/get")
+        networking.cancelGET("/get") {
+            completed = true
+        }
+
+        waitForExpectationsWithTimeout(15.0, handler: nil)
+    }
+
+    func testCancelGETWithID() {
+        let expectation = expectationWithDescription("testCancelGET")
+
+        let networking = Networking(baseURL: baseURL)
+        networking.disableTestingMode = true
+        var completed = false
+        let requestID = networking.GET("/get") { JSON, error in
+            XCTAssertTrue(completed)
+            XCTAssertEqual(error?.code, -999)
+            expectation.fulfill()
+        }
+
+        networking.cancel(requestID) {
+            completed = true
+        }
 
         waitForExpectationsWithTimeout(15.0, handler: nil)
     }

--- a/Tests/POSTTests.swift
+++ b/Tests/POSTTests.swift
@@ -184,17 +184,40 @@ class POSTTests: XCTestCase {
         }
     }
 
-    func testCancelPOST() {
+    func testCancelPOSTWithPath() {
         let expectation = expectationWithDescription("testCancelPOST")
 
         let networking = Networking(baseURL: baseURL)
         networking.disableTestingMode = true
+        var completed = false
         networking.POST("/post", parameters: ["username" : "jameson", "password" : "secret"]) { JSON, error in
+            XCTAssertTrue(completed)
             XCTAssertEqual(error?.code, -999)
             expectation.fulfill()
         }
 
-        networking.cancelPOST("/post")
+        networking.cancelPOST("/post") {
+            completed = true
+        }
+
+        waitForExpectationsWithTimeout(15.0, handler: nil)
+    }
+
+    func testCancelPOSTWithID() {
+        let expectation = expectationWithDescription("testCancelPOST")
+
+        let networking = Networking(baseURL: baseURL)
+        networking.disableTestingMode = true
+        var completed = false
+        let requestID = networking.POST("/post", parameters: ["username" : "jameson", "password" : "secret"]) { JSON, error in
+            XCTAssertTrue(completed)
+            XCTAssertEqual(error?.code, -999)
+            expectation.fulfill()
+        }
+
+        networking.cancel(requestID) {
+            completed = true
+        }
 
         waitForExpectationsWithTimeout(15.0, handler: nil)
     }

--- a/Tests/PUTTests.swift
+++ b/Tests/PUTTests.swift
@@ -79,17 +79,40 @@ class PUTTests: XCTestCase {
         }
     }
 
-    func testCancelPUT() {
+    func testCancelPUTWithPath() {
         let expectation = expectationWithDescription("testCancelPUT")
 
         let networking = Networking(baseURL: baseURL)
         networking.disableTestingMode = true
+        var completed = false
         networking.PUT("/put", parameters: ["username" : "jameson", "password" : "secret"]) { JSON, error in
+            XCTAssertTrue(completed)
             XCTAssertEqual(error?.code, -999)
             expectation.fulfill()
         }
 
-        networking.cancelPUT("/put")
+        networking.cancelPUT("/put") {
+            completed = true
+        }
+
+        waitForExpectationsWithTimeout(15.0, handler: nil)
+    }
+
+    func testCancelPUTWithID() {
+        let expectation = expectationWithDescription("testCancelPUT")
+
+        let networking = Networking(baseURL: baseURL)
+        networking.disableTestingMode = true
+        var completed = false
+        let requestID = networking.PUT("/put", parameters: ["username" : "jameson", "password" : "secret"]) { JSON, error in
+            XCTAssertTrue(completed)
+            XCTAssertEqual(error?.code, -999)
+            expectation.fulfill()
+        }
+
+        networking.cancel(requestID) {
+            completed = true
+        }
 
         waitForExpectationsWithTimeout(15.0, handler: nil)
     }


### PR DESCRIPTION
Fixes #104

Using `cancelPOST("/post")` would cancel all POST request for the specific path, but in some cases this isn't what we want, for example trying to cancel one request when creating two resources at the same time, you would use the same path but different parameters, this is when ID based cancellation is useful.

```swift
let networking = Networking(baseURL: "http://httpbin.org")
let firstRequestID = networking.POST("/post", parameters: ["username" : "3lvis"]) { JSON, error in
    // result
}

let secondRequestID = networking.POST("/post", parameters: ["username" : "sgl0v"]) { JSON, error in
    // result
}

networking.cancel(firstRequestID)
```

The great thing is that you don't want to use the ID, you just ignore it. So this still works without warnings.

```swift
let networking = Networking(baseURL: "http://httpbin.org")
networking.POST("/post", parameters: ["username" : "3lvis"]) { JSON, error in
    // result
}
```

This PR also adds optional completion handlers to all cancellation methods.