### PR TITLE
Remove check for error when handling response data

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -405,13 +405,11 @@ extension Networking {
                 requestID = self.dataRequest(requestType, path: path, cacheName: cacheName, parameterType: parameterType, parameters: parameters, parts: parts, responseType: responseType) { data, headers, error in
                     var returnedError = error
                     var returnedResponse: AnyObject?
-                    if error == nil {
-                        if let data = data where data.count > 0 {
-                            do {
-                                returnedResponse = try JSONSerialization.jsonObject(with: data, options: [])
-                            } catch let JSONError as NSError {
-                                returnedError = JSONError
-                            }
+                    if let data = data where data.count > 0 {
+                        do {
+                            returnedResponse = try JSONSerialization.jsonObject(with: data, options: [])
+                        } catch let JSONError as NSError {
+                            returnedError = JSONError
                         }
                     }
 


### PR DESCRIPTION
- Even thought there is an error thrown by the server here, we still want the actual data the server sent alongside, if there's any.
  Although you won't always have one, or even need, it should come down to the API consumer to decide if they want to ignore it or use it. 👌😁