### PR TITLE
Support removing cached files

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -601,6 +601,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 44DFD39E1D9A2D5A0014E9F2 /* Build configuration list for PBXNativeTarget "iOSDemo" */;
 			buildPhases = (
+				4405BBF01D9B64A400C703D4 /* Format Swift Code */,
 				44DFD3891D9A2D5A0014E9F2 /* Sources */,
 				44DFD38A1D9A2D5A0014E9F2 /* Frameworks */,
 				44DFD38B1D9A2D5A0014E9F2 /* Resources */,
@@ -805,6 +806,20 @@
 			shellScript = "\"${SRCROOT}/swiftformat\" \"${SRCROOT}/Sources\"";
 		};
 		140372E31D8F397F00F5F502 /* Format Swift Code */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Format Swift Code";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/swiftformat\" \"${SRCROOT}/Sources\"";
+		};
+		4405BBF01D9B64A400C703D4 /* Format Swift Code */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1574,6 +1589,7 @@
 				44DFD39D1D9A2D5A0014E9F2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -151,6 +151,10 @@
 		44B5D3A51D19B9E5004378B9 /* pig.png in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE31CF1D0D700049AD6 /* pig.png */; };
 		44B5D3A61D19B9E5004378B9 /* døgnvillburgere.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEDE1CF1D0D700049AD6 /* døgnvillburgere.jpg */; };
 		44B5D3A71D19B9E5004378B9 /* sample.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE41CF1D0D700049AD6 /* sample.jpg */; };
+		44DFD3901D9A2D5A0014E9F2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DFD38F1D9A2D5A0014E9F2 /* AppDelegate.swift */; };
+		44DFD3921D9A2D5A0014E9F2 /* OptionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DFD3911D9A2D5A0014E9F2 /* OptionsController.swift */; };
+		44DFD3971D9A2D5A0014E9F2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 44DFD3961D9A2D5A0014E9F2 /* Assets.xcassets */; };
+		44DFD39A1D9A2D5A0014E9F2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 44DFD3981D9A2D5A0014E9F2 /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -200,6 +204,12 @@
 		449687B41D1A433A000CF016 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		44B5D3AB1D19B9E5004378B9 /* tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tvOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		44B5D3AE1D19BA66004378B9 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		44DFD38D1D9A2D5A0014E9F2 /* iOSDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		44DFD38F1D9A2D5A0014E9F2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		44DFD3911D9A2D5A0014E9F2 /* OptionsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsController.swift; sourceTree = "<group>"; };
+		44DFD3961D9A2D5A0014E9F2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		44DFD3991D9A2D5A0014E9F2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		44DFD39B1D9A2D5A0014E9F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -252,6 +262,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		44DFD38A1D9A2D5A0014E9F2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -282,6 +299,7 @@
 				146D72AF1AB782920058798C /* iOSTests */,
 				44B5D3AD1D19BA66004378B9 /* tvOSTests */,
 				449687B31D1A433A000CF016 /* macOSTests */,
+				44DFD38E1D9A2D5A0014E9F2 /* iOSDemo */,
 				146D72941AB782920058798C /* Products */,
 				7C7551124581063F7B41A916 /* Frameworks */,
 			);
@@ -299,6 +317,7 @@
 				14638D3E1CC647E4002B9433 /* Networking.framework */,
 				1413F4551CE795DC00482096 /* macOSTests.xctest */,
 				44B5D3AB1D19B9E5004378B9 /* tvOSTests.xctest */,
+				44DFD38D1D9A2D5A0014E9F2 /* iOSDemo.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -372,6 +391,18 @@
 				44B5D3AE1D19BA66004378B9 /* Info.plist */,
 			);
 			path = tvOSTests;
+			sourceTree = "<group>";
+		};
+		44DFD38E1D9A2D5A0014E9F2 /* iOSDemo */ = {
+			isa = PBXGroup;
+			children = (
+				44DFD38F1D9A2D5A0014E9F2 /* AppDelegate.swift */,
+				44DFD3911D9A2D5A0014E9F2 /* OptionsController.swift */,
+				44DFD3961D9A2D5A0014E9F2 /* Assets.xcassets */,
+				44DFD3981D9A2D5A0014E9F2 /* LaunchScreen.storyboard */,
+				44DFD39B1D9A2D5A0014E9F2 /* Info.plist */,
+			);
+			path = iOSDemo;
 			sourceTree = "<group>";
 		};
 		7C7551124581063F7B41A916 /* Frameworks */ = {
@@ -545,6 +576,23 @@
 			productReference = 44B5D3AB1D19B9E5004378B9 /* tvOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		44DFD38C1D9A2D5A0014E9F2 /* iOSDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 44DFD39E1D9A2D5A0014E9F2 /* Build configuration list for PBXNativeTarget "iOSDemo" */;
+			buildPhases = (
+				44DFD3891D9A2D5A0014E9F2 /* Sources */,
+				44DFD38A1D9A2D5A0014E9F2 /* Frameworks */,
+				44DFD38B1D9A2D5A0014E9F2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iOSDemo;
+			productName = iOSDemo;
+			productReference = 44DFD38D1D9A2D5A0014E9F2 /* iOSDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -552,7 +600,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = "";
-				LastSwiftUpdateCheck = 0730;
+				LastSwiftUpdateCheck = 0800;
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
@@ -598,6 +646,10 @@
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Manual;
 					};
+					44DFD38C1D9A2D5A0014E9F2 = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 146D728E1AB782920058798C /* Build configuration list for PBXProject "Demo" */;
@@ -613,6 +665,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				44DFD38C1D9A2D5A0014E9F2 /* iOSDemo */,
 				146D72AB1AB782920058798C /* iOSTests */,
 				44B5D3881D19B9E5004378B9 /* tvOSTests */,
 				1413F4541CE795DC00482096 /* macOSTests */,
@@ -686,6 +739,15 @@
 				44B5D3A51D19B9E5004378B9 /* pig.png in Resources */,
 				44B5D3A61D19B9E5004378B9 /* døgnvillburgere.jpg in Resources */,
 				44B5D3A71D19B9E5004378B9 /* sample.jpg in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44DFD38B1D9A2D5A0014E9F2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44DFD39A1D9A2D5A0014E9F2 /* LaunchScreen.storyboard in Resources */,
+				44DFD3971D9A2D5A0014E9F2 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -911,7 +973,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		44DFD3891D9A2D5A0014E9F2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				44DFD3921D9A2D5A0014E9F2 /* OptionsController.swift in Sources */,
+				44DFD3901D9A2D5A0014E9F2 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		44DFD3981D9A2D5A0014E9F2 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				44DFD3991D9A2D5A0014E9F2 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		1413F45B1CE795DC00482096 /* Debug */ = {
@@ -1331,6 +1413,47 @@
 			};
 			name = Release;
 		};
+		44DFD39C1D9A2D5A0014E9F2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = iOSDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.3lvis.networking.iOSDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		44DFD39D1D9A2D5A0014E9F2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = iOSDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.3lvis.networking.iOSDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1405,6 +1528,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		44DFD39E1D9A2D5A0014E9F2 /* Build configuration list for PBXNativeTarget "iOSDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				44DFD39C1D9A2D5A0014E9F2 /* Debug */,
+				44DFD39D1D9A2D5A0014E9F2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -113,7 +113,6 @@
 		14B0CEE81CF1D0D700049AD6 /* entries.json in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEDF1CF1D0D700049AD6 /* entries.json */; };
 		14B0CEE91CF1D0D700049AD6 /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE11CF1D0D700049AD6 /* Keys.plist */; };
 		14B0CEEA1CF1D0D700049AD6 /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE11CF1D0D700049AD6 /* Keys.plist */; };
-		14B0CEEB1CF1D0D700049AD6 /* pig.png in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE31CF1D0D700049AD6 /* pig.png */; };
 		14B0CEEC1CF1D0D700049AD6 /* pig.png in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE31CF1D0D700049AD6 /* pig.png */; };
 		14B0CEED1CF1D0D700049AD6 /* sample.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE41CF1D0D700049AD6 /* sample.jpg */; };
 		14B0CEEE1CF1D0D700049AD6 /* sample.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE41CF1D0D700049AD6 /* sample.jpg */; };
@@ -155,6 +154,24 @@
 		44DFD3921D9A2D5A0014E9F2 /* OptionsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DFD3911D9A2D5A0014E9F2 /* OptionsController.swift */; };
 		44DFD3971D9A2D5A0014E9F2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 44DFD3961D9A2D5A0014E9F2 /* Assets.xcassets */; };
 		44DFD39A1D9A2D5A0014E9F2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 44DFD3981D9A2D5A0014E9F2 /* LaunchScreen.storyboard */; };
+		44DFD3A01D9A2EA70014E9F2 /* CellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DFD39F1D9A2EA70014E9F2 /* CellData.swift */; };
+		44DFD3A21D9A33610014E9F2 /* FakeImageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44DFD3A11D9A33610014E9F2 /* FakeImageController.swift */; };
+		44DFD3A31D9A344B0014E9F2 /* Dictionary+FormURLEncoded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474C1BC1CA2988900E15D84 /* Dictionary+FormURLEncoded.swift */; };
+		44DFD3A41D9A344D0014E9F2 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474C1BD1CA2988900E15D84 /* JSON.swift */; };
+		44DFD3A51D9A34500014E9F2 /* NetworkActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474C1BE1CA2988900E15D84 /* NetworkActivityIndicator.swift */; };
+		44DFD3A61D9A34540014E9F2 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474C1C11CA2988900E15D84 /* Networking.swift */; };
+		44DFD3A71D9A34540014E9F2 /* Networking+Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474C1C01CA2988900E15D84 /* Networking+Image.swift */; };
+		44DFD3A81D9A34540014E9F2 /* Networking+GET.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147B32EE1CF9B1C500D5BAED /* Networking+GET.swift */; };
+		44DFD3A91D9A34540014E9F2 /* Networking+POST.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147B32EF1CF9B1C500D5BAED /* Networking+POST.swift */; };
+		44DFD3AA1D9A34540014E9F2 /* Networking+PUT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147B32F01CF9B1C500D5BAED /* Networking+PUT.swift */; };
+		44DFD3AB1D9A34540014E9F2 /* Networking+DELETE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147B32ED1CF9B1C500D5BAED /* Networking+DELETE.swift */; };
+		44DFD3AC1D9A34540014E9F2 /* NSFileManager+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14676B951CCB490C00FFDC92 /* NSFileManager+Helpers.swift */; };
+		44DFD3AD1D9A34540014E9F2 /* String+UTF8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1413C1D51CBD1784000AF90F /* String+UTF8.swift */; };
+		44DFD3AE1D9A34540014E9F2 /* TestCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474C1C21CA2988900E15D84 /* TestCheck.swift */; };
+		44DFD3AF1D9A34540014E9F2 /* FormDataPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D144DD1CEED63B00048629 /* FormDataPart.swift */; };
+		44DFD3B01D9A34540014E9F2 /* NetworkingImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148341701CF1CF0500E91F01 /* NetworkingImage.swift */; };
+		44DFD3B11D9A3FC80014E9F2 /* pig.png in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE31CF1D0D700049AD6 /* pig.png */; };
+		44DFD3B21D9A3FC90014E9F2 /* pig.png in Resources */ = {isa = PBXBuildFile; fileRef = 14B0CEE31CF1D0D700049AD6 /* pig.png */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -210,6 +227,8 @@
 		44DFD3961D9A2D5A0014E9F2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		44DFD3991D9A2D5A0014E9F2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		44DFD39B1D9A2D5A0014E9F2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		44DFD39F1D9A2EA70014E9F2 /* CellData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellData.swift; sourceTree = "<group>"; };
+		44DFD3A11D9A33610014E9F2 /* FakeImageController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeImageController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -396,8 +415,10 @@
 		44DFD38E1D9A2D5A0014E9F2 /* iOSDemo */ = {
 			isa = PBXGroup;
 			children = (
+				44DFD39F1D9A2EA70014E9F2 /* CellData.swift */,
 				44DFD38F1D9A2D5A0014E9F2 /* AppDelegate.swift */,
 				44DFD3911D9A2D5A0014E9F2 /* OptionsController.swift */,
+				44DFD3A11D9A33610014E9F2 /* FakeImageController.swift */,
 				44DFD3961D9A2D5A0014E9F2 /* Assets.xcassets */,
 				44DFD3981D9A2D5A0014E9F2 /* LaunchScreen.storyboard */,
 				44DFD39B1D9A2D5A0014E9F2 /* Info.plist */,
@@ -722,9 +743,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44DFD3B11D9A3FC80014E9F2 /* pig.png in Resources */,
 				14B0CEE91CF1D0D700049AD6 /* Keys.plist in Resources */,
 				14B0CEE71CF1D0D700049AD6 /* entries.json in Resources */,
-				14B0CEEB1CF1D0D700049AD6 /* pig.png in Resources */,
 				14B0CEE51CF1D0D700049AD6 /* døgnvillburgere.jpg in Resources */,
 				14B0CEED1CF1D0D700049AD6 /* sample.jpg in Resources */,
 			);
@@ -746,6 +767,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44DFD3B21D9A3FC90014E9F2 /* pig.png in Resources */,
 				44DFD39A1D9A2D5A0014E9F2 /* LaunchScreen.storyboard in Resources */,
 				44DFD3971D9A2D5A0014E9F2 /* Assets.xcassets in Resources */,
 			);
@@ -977,8 +999,24 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44DFD3AB1D9A34540014E9F2 /* Networking+DELETE.swift in Sources */,
+				44DFD3A51D9A34500014E9F2 /* NetworkActivityIndicator.swift in Sources */,
+				44DFD3AF1D9A34540014E9F2 /* FormDataPart.swift in Sources */,
+				44DFD3A71D9A34540014E9F2 /* Networking+Image.swift in Sources */,
 				44DFD3921D9A2D5A0014E9F2 /* OptionsController.swift in Sources */,
+				44DFD3AC1D9A34540014E9F2 /* NSFileManager+Helpers.swift in Sources */,
+				44DFD3AA1D9A34540014E9F2 /* Networking+PUT.swift in Sources */,
+				44DFD3A91D9A34540014E9F2 /* Networking+POST.swift in Sources */,
 				44DFD3901D9A2D5A0014E9F2 /* AppDelegate.swift in Sources */,
+				44DFD3AE1D9A34540014E9F2 /* TestCheck.swift in Sources */,
+				44DFD3A61D9A34540014E9F2 /* Networking.swift in Sources */,
+				44DFD3A21D9A33610014E9F2 /* FakeImageController.swift in Sources */,
+				44DFD3A81D9A34540014E9F2 /* Networking+GET.swift in Sources */,
+				44DFD3AD1D9A34540014E9F2 /* String+UTF8.swift in Sources */,
+				44DFD3A41D9A344D0014E9F2 /* JSON.swift in Sources */,
+				44DFD3B01D9A34540014E9F2 /* NetworkingImage.swift in Sources */,
+				44DFD3A01D9A2EA70014E9F2 /* CellData.swift in Sources */,
+				44DFD3A31D9A344B0014E9F2 /* Dictionary+FormURLEncoded.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo.xcodeproj/xcshareddata/xcschemes/iOSDemo.xcscheme
+++ b/Demo.xcodeproj/xcshareddata/xcschemes/iOSDemo.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "44DFD38C1D9A2D5A0014E9F2"
+               BuildableName = "iOSDemo.app"
+               BlueprintName = "iOSDemo"
+               ReferencedContainer = "container:Demo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "44DFD38C1D9A2D5A0014E9F2"
+            BuildableName = "iOSDemo.app"
+            BlueprintName = "iOSDemo"
+            ReferencedContainer = "container:Demo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "44DFD38C1D9A2D5A0014E9F2"
+            BuildableName = "iOSDemo.app"
+            BlueprintName = "iOSDemo"
+            ReferencedContainer = "container:Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "44DFD38C1D9A2D5A0014E9F2"
+            BuildableName = "iOSDemo.app"
+            BlueprintName = "iOSDemo"
+            ReferencedContainer = "container:Demo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/NSFileManager+Helpers.swift
+++ b/Sources/NSFileManager+Helpers.swift
@@ -10,6 +10,8 @@ extension FileManager {
 
     public func remove(at url: URL) {
         let path = url.path
+        guard FileManager.default.isDeletableFile(atPath: url.path) else { return }
+
         do {
             try FileManager.default.removeItem(atPath: path)
         } catch let error as NSError {

--- a/Sources/Networking+DELETE.swift
+++ b/Sources/Networking+DELETE.swift
@@ -37,7 +37,7 @@ public extension Networking {
      - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the response object will be returned, otherwise we will return an error containig the provided status code.
      */
     public func fakeDELETE(_ path: String, response: Any?, statusCode: Int = 200) {
-        self.fake(.DELETE, path: path, response: response, statusCode: statusCode)
+        self.fake(.DELETE, path: path, response: response, responseType: .json, statusCode: statusCode)
     }
 
     /** 

--- a/Sources/Networking+GET.swift
+++ b/Sources/Networking+GET.swift
@@ -37,7 +37,7 @@ public extension Networking {
      - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the response object will be returned, otherwise we will return an error containig the provided status code.
      */
     public func fakeGET(_ path: String, response: Any?, statusCode: Int = 200) {
-        self.fake(.GET, path: path, response: response, statusCode: statusCode)
+        self.fake(.GET, path: path, response: response, responseType: .json, statusCode: statusCode)
     }
 
     /** 

--- a/Sources/Networking+Image.swift
+++ b/Sources/Networking+Image.swift
@@ -58,6 +58,6 @@ public extension Networking {
      - parameter image: An image that will be returned when there's a request to the registered path.
      */
     public func fakeImageDownload(_ path: String, image: NetworkingImage?, statusCode: Int = 200) {
-        self.fake(.GET, path: path, response: image, statusCode: statusCode)
+        self.fake(.GET, path: path, response: image, responseType: .image, statusCode: statusCode)
     }
 }

--- a/Sources/Networking+POST.swift
+++ b/Sources/Networking+POST.swift
@@ -71,7 +71,7 @@ public extension Networking {
      - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the response object will be returned, otherwise we will return an error containig the provided status code.
      */
     public func fakePOST(_ path: String, response: Any?, statusCode: Int = 200) {
-        self.fake(.POST, path: path, response: response, statusCode: statusCode)
+        self.fake(.POST, path: path, response: response, responseType: .json, statusCode: statusCode)
     }
 
     /** 

--- a/Sources/Networking+PUT.swift
+++ b/Sources/Networking+PUT.swift
@@ -39,7 +39,7 @@ public extension Networking {
      - parameter statusCode: By default it's 200, if you provide any status code that is between 200 and 299 the response object will be returned, otherwise we will return an error containig the provided status code.
      */
     public func fakePUT(_ path: String, response: Any?, statusCode: Int = 200) {
-        self.fake(.PUT, path: path, response: response, statusCode: statusCode)
+        self.fake(.PUT, path: path, response: response, responseType: .json, statusCode: statusCode)
     }
 
     /** 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -211,7 +211,7 @@ public class Networking {
                 try (cachesURL as NSURL).setResourceValue(true, forKey: URLResourceKey.isExcludedFromBackupKey)
                 let folderURL = cachesURL.appendingPathComponent(URL(string: folderPath)!.absoluteString)
 
-                if FileManager.default.fileExists(atPath: folderURL.path) == false {
+                if FileManager.default.exists(at: folderURL) == false {
                     try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: false, attributes: nil)
                 }
 
@@ -322,6 +322,19 @@ public class Networking {
         let object = self.objectFromCache(for: path, cacheName: cacheName, responseType: .data)
 
         return object as? Data
+    }
+
+    /** 
+     Deletes the downloaded/cached files.
+     */
+    public static func deleteDownloadedFiles() {
+        if let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            let folderURL = cachesURL.appendingPathComponent(URL(string: Networking.domain)!.absoluteString)
+
+            if FileManager.default.exists(at: folderURL) {
+                FileManager.default.remove(at: folderURL)
+            }
+        }
     }
 }
 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -327,7 +327,7 @@ public class Networking {
     /** 
      Deletes the downloaded/cached files.
      */
-    public static func deleteDownloadedFiles() {
+    public static func deleteCachedFiles() {
         if let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
             let folderURL = cachesURL.appendingPathComponent(URL(string: Networking.domain)!.absoluteString)
 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -399,16 +399,6 @@ extension Networking {
 
         if let fakeRequests = self.fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
             if fakeRequest.statusCode.statusCodeType() == .successful {
-                if fakeRequest.responseType == .image {
-                    let trimmedPath = path.components(separatedBy: "?").first!
-                    let image = fakeRequest.response as? NetworkingImage
-                    if let image = image, let data = image.pngData(), data.count > 0 {
-                        guard let destinationURL = try? self.destinationURL(for: trimmedPath, cacheName: cacheName) else { fatalError("Couldn't get destination URL for path: \(path) and cacheName: \(cacheName)") }
-                        let _ = try? data.write(to: destinationURL, options: [.atomic])
-                        self.cache.setObject(image, forKey: destinationURL.absoluteString as AnyObject)
-                    }
-                }
-
                 completion(fakeRequest.response, [String: Any](), nil)
             } else {
                 let error = NSError(domain: Networking.domain, code: fakeRequest.statusCode, userInfo: [NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: fakeRequest.statusCode)])

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -190,7 +190,7 @@ public class Networking {
      - returns: A NSURL generated after appending the path to the base URL.
      */
     public func url(for path: String) -> URL {
-        guard let encodedPath = path.encodeUTF8() else { fatalError("Couldn't encode path to UTF8: \(path)") }
+        let encodedPath = path.encodeUTF8() ?? path
         guard let url = URL(string: self.baseURL + encodedPath) else { fatalError("Couldn't create a url using baseURL: \(self.baseURL) and encodedPath: \(encodedPath)") }
         return url
     }
@@ -201,14 +201,13 @@ public class Networking {
      - returns: A NSURL where a resource has been stored.
      */
     public func destinationURL(for path: String, cacheName: String? = nil) throws -> URL {
-        let directory = FileManager.SearchPathDirectory.cachesDirectory
         let resourcesPath = cacheName ?? self.url(for: path).absoluteString
         let normalizedResourcesPath = resourcesPath.replacingOccurrences(of: "/", with: "-")
         let folderPath = Networking.domain
         let finalPath = "\(folderPath)/\(normalizedResourcesPath)"
 
         if let url = URL(string: finalPath) {
-            if let cachesURL = FileManager.default.urls(for: directory, in: .userDomainMask).first {
+            if let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
                 try (cachesURL as NSURL).setResourceValue(true, forKey: URLResourceKey.isExcludedFromBackupKey)
                 let folderURL = cachesURL.appendingPathComponent(URL(string: folderPath)!.absoluteString)
 

--- a/Tests/GETTests.swift
+++ b/Tests/GETTests.swift
@@ -154,14 +154,14 @@ class GETTests: XCTestCase {
         var statusCode = 300
         networking.GET("/status/\(statusCode)") { JSON, error in
             XCTAssertNil(JSON)
-            let connectionError = NSError(domain: Networking.ErrorDomain, code: statusCode, userInfo: [NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: statusCode)])
+            let connectionError = NSError(domain: Networking.domain, code: statusCode, userInfo: [NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: statusCode)])
             XCTAssertEqual(error, connectionError)
         }
 
         statusCode = 400
         networking.GET("/status/\(statusCode)") { JSON, error in
             XCTAssertNil(JSON)
-            let connectionError = NSError(domain: Networking.ErrorDomain, code: statusCode, userInfo: [NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: statusCode)])
+            let connectionError = NSError(domain: Networking.domain, code: statusCode, userInfo: [NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: statusCode)])
             XCTAssertEqual(error, connectionError)
         }
     }

--- a/Tests/Helpers.swift
+++ b/Tests/Helpers.swift
@@ -8,15 +8,4 @@ struct Helper {
             FileManager.default.remove(at: destinationURL)
         }
     }
-
-    static func cleanDownloadsFolder() {
-        if let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
-            let folderURL = cachesURL.appendingPathComponent(URL(string: Networking.domain)!.absoluteString)
-            print("folderURL: \(folderURL)")
-
-            if FileManager.default.exists(at: folderURL) {
-                FileManager.default.remove(at: folderURL)
-            }
-        }
-    }
 }

--- a/Tests/Helpers.swift
+++ b/Tests/Helpers.swift
@@ -8,4 +8,15 @@ struct Helper {
             FileManager.default.remove(at: destinationURL)
         }
     }
+
+    static func cleanDownloadsFolder() {
+        if let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            let folderURL = cachesURL.appendingPathComponent(URL(string: Networking.domain)!.absoluteString)
+            print("folderURL: \(folderURL)")
+
+            if FileManager.default.exists(at: folderURL) {
+                FileManager.default.remove(at: folderURL)
+            }
+        }
+    }
 }

--- a/Tests/ImageTests.swift
+++ b/Tests/ImageTests.swift
@@ -166,7 +166,7 @@ class ImageTests: XCTestCase {
     func testImageFromCacheForPathInCache() {
         let networking = Networking(baseURL: self.baseURL)
         let path = "/image/png"
-        Helper.removeFileIfNeeded(networking, path: path)
+        Helper.cleanDownloadsFolder()
         networking.downloadImage(path) { image, error in
             let image = networking.imageFromCache(path)
             let pigImage = NetworkingImage.find(named: "pig.png", inBundle: Bundle(for: ImageTests.self))

--- a/Tests/ImageTests.swift
+++ b/Tests/ImageTests.swift
@@ -166,7 +166,7 @@ class ImageTests: XCTestCase {
     func testImageFromCacheForPathInCache() {
         let networking = Networking(baseURL: self.baseURL)
         let path = "/image/png"
-        Networking.deleteDownloadedFiles()
+        Networking.deleteCachedFiles()
         networking.downloadImage(path) { image, error in
             let image = networking.imageFromCache(path)
             let pigImage = NetworkingImage.find(named: "pig.png", inBundle: Bundle(for: ImageTests.self))

--- a/Tests/ImageTests.swift
+++ b/Tests/ImageTests.swift
@@ -243,16 +243,4 @@ class ImageTests: XCTestCase {
             XCTAssertNil(image)
         }
     }
-
-    func testCacheRetrieval() {
-        let cache = NSCache<AnyObject, AnyObject>()
-        let networking = Networking(baseURL: "http://store.storeimages.cdn-apple.com", cache: cache)
-        let path = "/4973/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/pro/ipad-pro-201603-gallery3?wid=4000&amp%3Bhei=1536&amp%3Bfmt=jpeg&amp%3Bqlt=95&amp%3Bop_sharpen=0&amp%3BresMode=bicub&amp%3Bop_usm=0.5%2C0.5%2C0%2C0&amp%3BiccEmbed=0&amp%3Blayer=comp&amp%3B.v=Y7wkx0&hei=3072"
-
-        networking.downloadData(for: path) { downloadData, error in
-            let cacheKey = path.components(separatedBy: "?").first!
-            let cacheData = networking.dataFromCache(for: cacheKey)
-            XCTAssert(downloadData == cacheData!)
-        }
-    }
 }

--- a/Tests/ImageTests.swift
+++ b/Tests/ImageTests.swift
@@ -166,7 +166,7 @@ class ImageTests: XCTestCase {
     func testImageFromCacheForPathInCache() {
         let networking = Networking(baseURL: self.baseURL)
         let path = "/image/png"
-        Helper.cleanDownloadsFolder()
+        Networking.deleteDownloadedFiles()
         networking.downloadImage(path) { image, error in
             let image = networking.imageFromCache(path)
             let pigImage = NetworkingImage.find(named: "pig.png", inBundle: Bundle(for: ImageTests.self))

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -168,7 +168,7 @@ class NetworkingTests: XCTestCase {
     }
 
 
-    func testCacheRetrieval() {
+    func testDataFromCache() {
         let cache = NSCache<AnyObject, AnyObject>()
         let networking = Networking(baseURL: "http://store.storeimages.cdn-apple.com", cache: cache)
         let path = "/4973/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/pro/ipad-pro-201603-gallery3?wid=4000&amp%3Bhei=1536&amp%3Bfmt=jpeg&amp%3Bqlt=95&amp%3Bop_sharpen=0&amp%3BresMode=bicub&amp%3Bop_usm=0.5%2C0.5%2C0%2C0&amp%3BiccEmbed=0&amp%3Blayer=comp&amp%3B.v=Y7wkx0&hei=3072"

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -167,8 +167,17 @@ class NetworkingTests: XCTestCase {
         XCTAssertTrue(synchronous)
     }
 
-    // Needs tests
-    func testDataFromCache() {
+
+    func testCacheRetrieval() {
+        let cache = NSCache<AnyObject, AnyObject>()
+        let networking = Networking(baseURL: "http://store.storeimages.cdn-apple.com", cache: cache)
+        let path = "/4973/as-images.apple.com/is/image/AppleInc/aos/published/images/i/pa/ipad/pro/ipad-pro-201603-gallery3?wid=4000&amp%3Bhei=1536&amp%3Bfmt=jpeg&amp%3Bqlt=95&amp%3Bop_sharpen=0&amp%3BresMode=bicub&amp%3Bop_usm=0.5%2C0.5%2C0%2C0&amp%3BiccEmbed=0&amp%3Blayer=comp&amp%3B.v=Y7wkx0&hei=3072"
+
+        networking.downloadData(for: path) { downloadData, error in
+            let cacheKey = path.components(separatedBy: "?").first!
+            let cacheData = networking.dataFromCache(for: cacheKey)
+            XCTAssert(downloadData == cacheData!)
+        }
     }
 
     func testDeleteDownloadedFiles() {

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -170,4 +170,15 @@ class NetworkingTests: XCTestCase {
     // Needs tests
     func testDataFromCache() {
     }
+
+    func testDeleteDownloadedFiles() {
+        let networking = Networking(baseURL: self.baseURL)
+        networking.downloadImage("/image/png") { image, error in
+            let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+            let folderURL = cachesURL.appendingPathComponent(URL(string: Networking.domain)!.absoluteString)
+            XCTAssertTrue(FileManager.default.exists(at: folderURL))
+            Networking.deleteDownloadedFiles()
+            XCTAssertFalse(FileManager.default.exists(at: folderURL))
+        }
+    }
 }

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -186,7 +186,7 @@ class NetworkingTests: XCTestCase {
             let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
             let folderURL = cachesURL.appendingPathComponent(URL(string: Networking.domain)!.absoluteString)
             XCTAssertTrue(FileManager.default.exists(at: folderURL))
-            Networking.deleteDownloadedFiles()
+            Networking.deleteCachedFiles()
             XCTAssertFalse(FileManager.default.exists(at: folderURL))
         }
     }

--- a/iOSDemo/AppDelegate.swift
+++ b/iOSDemo/AppDelegate.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder {
+    var window: UIWindow?
+}
+
+extension AppDelegate: UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        self.window = UIWindow(frame: UIScreen.main.bounds)
+
+        let controller = OptionsController(nibName: nil, bundle: nil)
+        let navigationController = UINavigationController(rootViewController: controller)
+        self.window?.rootViewController = navigationController
+
+        self.window?.makeKeyAndVisible()
+
+        return true
+    }
+}

--- a/iOSDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iOSDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/iOSDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iOSDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/iOSDemo/Base.lproj/LaunchScreen.storyboard
+++ b/iOSDemo/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/iOSDemo/CellData.swift
+++ b/iOSDemo/CellData.swift
@@ -1,0 +1,4 @@
+struct CellData {
+    let title: String
+    let action: ((Void) -> Void)
+}

--- a/iOSDemo/FakeImageController.swift
+++ b/iOSDemo/FakeImageController.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+class FakeImageController: UIViewController {
+    lazy var imageView: UIImageView = {
+        let view = UIImageView(frame: self.view.frame)
+        view.contentMode = .scaleAspectFit
+
+        return view
+    }()
+
+    lazy var networking: Networking = {
+        let networking = Networking(baseURL: "http://httpbin.org")
+
+        let image = UIImage(named: "pig.png")
+        networking.fakeImageDownload("/pig", image: image)
+
+        return networking
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.view.backgroundColor = .white
+        self.view.addSubview(self.imageView)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        self.networking.downloadImage("/pig") { image, error in
+            self.imageView.image = image
+        }
+    }
+}

--- a/iOSDemo/Info.plist
+++ b/iOSDemo/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+</dict>
+</plist>

--- a/iOSDemo/Info.plist
+++ b/iOSDemo/Info.plist
@@ -29,9 +29,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 </dict>
 </plist>

--- a/iOSDemo/OptionsController.swift
+++ b/iOSDemo/OptionsController.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+class OptionsController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.view.backgroundColor = UIColor.red
+    }
+}
+

--- a/iOSDemo/OptionsController.swift
+++ b/iOSDemo/OptionsController.swift
@@ -1,10 +1,60 @@
 import UIKit
 
-class OptionsController: UIViewController {
+class OptionsController: UITableViewController {
+    var cellIdentifier: String {
+        return String(describing: UITableViewCell.self)
+    }
+
+    lazy var data: [[CellData]] = {
+        var data = [[CellData]]()
+
+        var firstSection = [CellData]()
+
+        firstSection.append(CellData(title: "Fake image") {
+            let controller = FakeImageController(nibName: nil, bundle: nil)
+            self.navigationController?.pushViewController(controller, animated: true)
+        })
+
+        data.append(firstSection)
+
+        return data
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.view.backgroundColor = UIColor.red
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.cellIdentifier)
+    }
+
+    func object(at indexPath: IndexPath) -> CellData {
+        let section = self.data[indexPath.section]
+        let object = section[indexPath.row]
+
+        return object
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return self.data.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        let section = self.data[section]
+
+        return section.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: self.cellIdentifier, for: indexPath)
+
+        let object = self.object(at: indexPath)
+        cell.textLabel?.text = object.title
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let object = self.object(at: indexPath)
+        object.action()
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/3lvis/Networking/issues/47

When you use `downloadImage` it gets saved into little files in your caches folder. Thanks to this method you can clean that cache.
```swift
Networking.deleteDownloadedFiles()
```