### PR TITLE
Update method name for clarity

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -154,7 +154,7 @@ public class Networking {
      - parameter username: The username to be used.
      - parameter password: The password to be used.
      */
-    public func authenticate(username: String, password: String) {
+    public func addBasicAuthenticationField(username: String, password: String) {
         let credentialsString = "\(username):\(password)"
         if let credentialsData = credentialsString.data(using: .utf8) {
             let base64Credentials = credentialsData.base64EncodedString(options: [])
@@ -170,7 +170,7 @@ public class Networking {
      Authenticates using a Bearer token, sets the Authorization header to "Bearer \(token)".
      - parameter token: The token to be used.
      */
-    public func authenticate(token: String) {
+    public func addBasicAuthenticationField(token: String) {
         self.token = token
     }
 
@@ -179,7 +179,7 @@ public class Networking {
      - parameter authorizationHeaderKey: Sets this value as the key for the HTTP `Authorization` header
      - parameter authorizationHeaderValue: Sets this value to the HTTP `Authorization` header or to the `headerKey` if you provided that.
      */
-    public func authenticate(headerKey: String = "Authorization", headerValue: String) {
+    public func addBasicAuthenticationHeader(headerKey: String = "Authorization", headerValue: String) {
         self.authorizationHeaderKey = headerKey
         self.authorizationHeaderValue = headerValue
     }

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -6,7 +6,7 @@ class NetworkingTests: XCTestCase {
 
     func testBasicAuth() {
         let networking = Networking(baseURL: baseURL)
-        networking.authenticate(username: "user", password: "passwd")
+        networking.addBasicAuthenticationField(username: "user", password: "passwd")
         networking.GET("/basic-auth/user/passwd") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let user = JSON["user"] as? String
@@ -19,7 +19,7 @@ class NetworkingTests: XCTestCase {
     func testBearerTokenAuth() {
         let networking = Networking(baseURL: baseURL)
         let token = "hi-mom"
-        networking.authenticate(token: token)
+        networking.addBasicAuthenticationField(token: token)
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
@@ -30,7 +30,7 @@ class NetworkingTests: XCTestCase {
     func testCustomAuthorizationHeaderValue() {
         let networking = Networking(baseURL: baseURL)
         let value = "hi-mom"
-        networking.authenticate(headerValue: value)
+        networking.addBasicAuthenticationHeader(headerValue: value)
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
@@ -42,7 +42,7 @@ class NetworkingTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let key = "Anonymous-Token"
         let value = "hi-mom"
-        networking.authenticate(headerKey: key, headerValue: value)
+        networking.addBasicAuthenticationHeader(headerKey: key, headerValue: value)
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]

--- a/Tests/POSTTests.swift
+++ b/Tests/POSTTests.swift
@@ -219,7 +219,7 @@ class POSTTests: XCTestCase {
     }
 
     func deleteAllCloudinaryPhotos(networking: Networking, cloudName: String, secret: String, APIKey: String) {
-        networking.authenticate(username: APIKey, password: secret)
+        networking.addBasicAuthenticationField(username: APIKey, password: secret)
         networking.DELETE("/v1_1/\(cloudName)/resources/image/upload?all=true") { JSON, error in }
     }
 }


### PR DESCRIPTION
`authenticate` is itself a verb, and implies that by calling this method, the user will be authenticated. What in fact happens is that it will setup the next request to have the `basic auth` fields setup.

Did I get that right?

Suggestion for better naming welcome.