### PR TITLE
Rename authentication method

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -352,21 +352,21 @@
 		1474C1BB1CA2988900E15D84 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				1474C1BC1CA2988900E15D84 /* Dictionary+FormURLEncoded.swift */,
-				1474C1BD1CA2988900E15D84 /* JSON.swift */,
-				1474C1BE1CA2988900E15D84 /* NetworkActivityIndicator.swift */,
 				14638D031CC645D2002B9433 /* Networking.h */,
 				1474C1C11CA2988900E15D84 /* Networking.swift */,
-				1474C1C01CA2988900E15D84 /* Networking+Image.swift */,
 				147B32EE1CF9B1C500D5BAED /* Networking+GET.swift */,
 				147B32EF1CF9B1C500D5BAED /* Networking+POST.swift */,
 				147B32F01CF9B1C500D5BAED /* Networking+PUT.swift */,
 				147B32ED1CF9B1C500D5BAED /* Networking+DELETE.swift */,
+				1474C1C01CA2988900E15D84 /* Networking+Image.swift */,
+				14D144DD1CEED63B00048629 /* FormDataPart.swift */,
+				1474C1BC1CA2988900E15D84 /* Dictionary+FormURLEncoded.swift */,
 				14676B951CCB490C00FFDC92 /* NSFileManager+Helpers.swift */,
 				1413C1D51CBD1784000AF90F /* String+UTF8.swift */,
-				1474C1C21CA2988900E15D84 /* TestCheck.swift */,
-				14D144DD1CEED63B00048629 /* FormDataPart.swift */,
+				1474C1BD1CA2988900E15D84 /* JSON.swift */,
 				148341701CF1CF0500E91F01 /* NetworkingImage.swift */,
+				1474C1C21CA2988900E15D84 /* TestCheck.swift */,
+				1474C1BE1CA2988900E15D84 /* NetworkActivityIndicator.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -295,14 +295,14 @@
 			isa = PBXGroup;
 			children = (
 				14B0CEDD1CF1D0D700049AD6 /* Resources */,
-				1413F45E1CE7963700482096 /* Dictionary+FormURLEncodedTests.swift */,
-				1413F4611CE7963700482096 /* Helpers.swift */,
+				1413F4641CE7963700482096 /* NetworkingTests.swift */,
 				146EF90E1CEBCEA50059DDB1 /* GETTests.swift */,
 				146EF90F1CEBCEA50059DDB1 /* POSTTests.swift */,
 				146EF9101CEBCEA50059DDB1 /* PUTTests.swift */,
 				146EF90D1CEBCEA50059DDB1 /* DELETETests.swift */,
 				1413F4631CE7963700482096 /* ImageTests.swift */,
-				1413F4641CE7963700482096 /* NetworkingTests.swift */,
+				1413F45E1CE7963700482096 /* Dictionary+FormURLEncodedTests.swift */,
+				1413F4611CE7963700482096 /* Helpers.swift */,
 				1488E23C1CF138D700C6FBA3 /* SHA1.h */,
 				1488E23D1CF138D700C6FBA3 /* SHA1.m */,
 			);

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -119,7 +119,6 @@ public class Networking {
 
     private let baseURL: String
     var fakeRequests = [RequestType: [String: FakeRequest]]()
-    var token: String?
     var cache: NSCache<AnyObject, AnyObject>
     var configurationType: ConfigurationType
     fileprivate let authorizationHeaderKey = "Authorization"
@@ -146,6 +145,35 @@ public class Networking {
         self.baseURL = baseURL
         self.configurationType = configurationType
         self.cache = cache ?? NSCache()
+    }
+
+    /** 
+     Authenticates using Basic Authentication, it converts username:password to Base64 then sets the Authorization header to "Basic \(Base64(username:password))".
+     - parameter username: The username to be used.
+     - parameter password: The password to be used.
+     */
+    @available(*, deprecated: 2.2.0, message: "Use `var basicAuthenticationHeaderField` instead.")
+    public func authenticate(username: String, password: String) {
+        self.basicAuthenticationHeaderField = (username, password)
+    }
+
+    /** 
+     Authenticates using a Bearer token, sets the Authorization header to "Bearer \(token)".
+     - parameter token: The token to be used.
+     */
+    @available(*, deprecated: 2.2.0, message: "Use `var authenticationHeaderFieldValue` with \"Bearer \\(token)\" as value instead.")
+    public func authenticate(token: String) {
+        self.authenticationHeaderFieldValue = "Bearer \(token)"
+    }
+
+    /** 
+     Authenticates using a custom HTTP Authorization header.
+     - parameter authorizationHeaderKey: Sets this value as the key for the HTTP `Authorization` header
+     - parameter authorizationHeaderValue: Sets this value to the HTTP `Authorization` header or to the `headerKey` if you provided that.
+     */
+    @available(*, deprecated: 2.2.0, message: "Use `var headerFields` instead.")
+    public func authenticate(headerKey: String = "Authorization", headerValue: String) {
+        self.headerFields = [headerKey: headerValue]
     }
 
     /** 

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -154,7 +154,7 @@ public class Networking {
      - parameter username: The username to be used.
      - parameter password: The password to be used.
      */
-    public func authenticate(username: String, password: String) {
+    public func addBasicAuthenticationField(username: String, password: String) {
         let credentialsString = "\(username):\(password)"
         if let credentialsData = credentialsString.data(using: .utf8) {
             let base64Credentials = credentialsData.base64EncodedString(options: [])
@@ -170,7 +170,7 @@ public class Networking {
      Authenticates using a Bearer token, sets the Authorization header to "Bearer \(token)".
      - parameter token: The token to be used.
      */
-    public func authenticate(token: String) {
+    public func addBasicAuthenticationField(token: String) {
         self.token = token
     }
 
@@ -179,7 +179,7 @@ public class Networking {
      - parameter authorizationHeaderKey: Sets this value as the key for the HTTP `Authorization` header
      - parameter authorizationHeaderValue: Sets this value to the HTTP `Authorization` header or to the `headerKey` if you provided that.
      */
-    public func authenticate(headerKey: String = "Authorization", headerValue: String) {
+    public func addBasicAuthenticationHeader(headerKey: String = "Authorization", headerValue: String) {
         self.authorizationHeaderKey = headerKey
         self.authorizationHeaderValue = headerValue
     }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -119,9 +119,11 @@ public class Networking {
 
     private let baseURL: String
     var fakeRequests = [RequestType: [String: FakeRequest]]()
+    var token: String?
+    var authorizationHeaderValue: String?
+    var authorizationHeaderKey = "Authorization"
     var cache: NSCache<AnyObject, AnyObject>
     var configurationType: ConfigurationType
-    fileprivate let authorizationHeaderKey = "Authorization"
 
     /** 
      Flag used to disable synchronous request when running automatic tests.
@@ -152,34 +154,7 @@ public class Networking {
      - parameter username: The username to be used.
      - parameter password: The password to be used.
      */
-    @available(*, deprecated: 2.2.0, message: "Use `var basicAuthenticationHeaderField` instead.")
-    public func authenticate(username: String, password: String) {
-        self.setBasicAuthenticationHeader(username: username, password: password)
-    }
-
-    /** 
-     Authenticates using a Bearer token, sets the Authorization header to "Bearer \(token)".
-     - parameter token: The token to be used.
-     */
-    @available(*, deprecated: 2.2.0, message: "Use `var authenticationHeaderFieldValue` with \"Bearer \\(token)\" as value instead.")
-    public func authenticate(token: String) {
-        self.authenticationHeaderFieldValue = "Bearer \(token)"
-    }
-
-    /** 
-     Authenticates using a custom HTTP Authorization header.
-     - parameter authorizationHeaderKey: Sets this value as the key for the HTTP `Authorization` header
-     - parameter authorizationHeaderValue: Sets this value to the HTTP `Authorization` header or to the `headerKey` if you provided that.
-     */
-    @available(*, deprecated: 2.2.0, message: "Use `var headerFields` instead.")
-    public func authenticate(headerKey: String = "Authorization", headerValue: String) {
-        self.headerFields = [headerKey: headerValue]
-    }
-
-    /** 
-     Sets the HTTP "Authorization" header using Basic Authentication, it converts username:password to Base64 then sets the header to "Basic \(Base64(username:password))".
-     */
-    public func setBasicAuthenticationHeader(username: String, password: String) {
+    public func setAuthorizationHeader(username: String, password: String) {
         let credentialsString = "\(username):\(password)"
         if let credentialsData = credentialsString.data(using: .utf8) {
             let base64Credentials = credentialsData.base64EncodedString(options: [])
@@ -193,18 +168,50 @@ public class Networking {
 
     /** 
      Authenticates using a Bearer token, sets the Authorization header to "Bearer \(token)".
+     - parameter token: The token to be used.
      */
-    public var bearerTokenAuthenticationHeader: String?
+    public func setAuthorizationHeader(token: String) {
+        self.token = token
+    }
 
     /** 
-     Sets the value of the the HTTP "Authorization" header.
+     Authenticates using a custom HTTP Authorization header.
+     - parameter authorizationHeaderKey: Sets this value as the key for the HTTP `Authorization` header
+     - parameter authorizationHeaderValue: Sets this value to the HTTP `Authorization` header or to the `headerKey` if you provided that.
      */
-    public var authenticationHeaderFieldValue: String?
+    public func setAuthorizationHeader(headerKey: String = "Authorization", headerValue: String) {
+        self.authorizationHeaderKey = headerKey
+        self.authorizationHeaderValue = headerValue
+    }
 
     /** 
-     Sets the header fields for every HTTP call.
+     Authenticates using Basic Authentication, it converts username:password to Base64 then sets the Authorization header to "Basic \(Base64(username:password))".
+     - parameter username: The username to be used.
+     - parameter password: The password to be used.
      */
-    public var headerFields: [String: String]?
+    @available(*, deprecated: 2.2.0, message: "Use `func setAuthorizationHeader(username:password)` instead.")
+    public func authenticate(username: String, password: String) {
+        self.setAuthorizationHeader(username: username, password: password)
+    }
+
+    /** 
+     Authenticates using a Bearer token, sets the Authorization header to "Bearer \(token)".
+     - parameter token: The token to be used.
+     */
+    @available(*, deprecated: 2.2.0, message: "Use `func setAuthorizationHeader(token)` instead")
+    public func authenticate(token: String) {
+        self.setAuthorizationHeader(token: token)
+    }
+
+    /** 
+     Authenticates using a custom HTTP Authorization header.
+     - parameter authorizationHeaderKey: Sets this value as the key for the HTTP `Authorization` header
+     - parameter authorizationHeaderValue: Sets this value to the HTTP `Authorization` header or to the `headerKey` if you provided that.
+     */
+    @available(*, deprecated: 2.2.0, message: "Use `func setAuthorizationHeader(headerKey:headerValue)` instead.")
+    public func authenticate(headerKey: String = "Authorization", headerValue: String) {
+        self.setAuthorizationHeader(headerKey: headerKey, headerValue: headerValue)
+    }
 
     /** 
      Returns a NSURL by appending the provided path to the Networking's base URL.
@@ -524,18 +531,10 @@ extension Networking {
             request.addValue(accept, forHTTPHeaderField: "Accept")
         }
 
-        if let authenticationHeaderFieldValue = self.authenticationHeaderFieldValue {
-            request.setValue(authenticationHeaderFieldValue, forHTTPHeaderField: self.authorizationHeaderKey)
-        }
-
-        if let token = self.bearerTokenAuthenticationHeader {
+        if let authorizationHeader = self.authorizationHeaderValue {
+            request.setValue(authorizationHeader, forHTTPHeaderField: self.authorizationHeaderKey)
+        } else if let token = self.token {
             request.setValue("Bearer \(token)", forHTTPHeaderField: self.authorizationHeaderKey)
-        }
-
-        if let headerFields = self.headerFields {
-            for (key, value) in headerFields {
-                request.setValue(value, forHTTPHeaderField: key)
-            }
         }
 
         DispatchQueue.main.async {

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -4,6 +4,52 @@ import XCTest
 class NetworkingTests: XCTestCase {
     let baseURL = "http://httpbin.org"
 
+    func testBasicAuth() {
+        let networking = Networking(baseURL: baseURL)
+        networking.authenticate(username: "user", password: "passwd")
+        networking.GET("/basic-auth/user/passwd") { JSON, error in
+            guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
+            let user = JSON["user"] as? String
+            let authenticated = JSON["authenticated"] as? Bool
+            XCTAssertEqual(user, "user")
+            XCTAssertEqual(authenticated, true)
+        }
+    }
+
+    func testBearerTokenAuth() {
+        let networking = Networking(baseURL: baseURL)
+        let token = "hi-mom"
+        networking.authenticate(token: token)
+        networking.POST("/post") { JSON, error in
+            guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
+            let headers = JSON["headers"] as? [String: Any]
+            XCTAssertEqual("Bearer \(token)", headers?["Authorization"] as? String)
+        }
+    }
+
+    func testCustomAuthorizationHeaderValue() {
+        let networking = Networking(baseURL: baseURL)
+        let value = "hi-mom"
+        networking.authenticate(headerValue: value)
+        networking.POST("/post") { JSON, error in
+            guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
+            let headers = JSON["headers"] as? [String: Any]
+            XCTAssertEqual(value, headers?["Authorization"] as? String)
+        }
+    }
+
+    func testCustomAuthorizationHeaderValueAndHeaderKey() {
+        let networking = Networking(baseURL: baseURL)
+        let key = "Anonymous-Token"
+        let value = "hi-mom"
+        networking.authenticate(headerKey: key, headerValue: value)
+        networking.POST("/post") { JSON, error in
+            guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
+            let headers = JSON["headers"] as? [String: Any]
+            XCTAssertEqual(value, headers?[key] as? String)
+        }
+    }
+
     func testBasicAuthenticationHeaderField() {
         let networking = Networking(baseURL: baseURL)
         networking.basicAuthenticationHeaderField = (username: "user", password: "passwd")

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -52,8 +52,8 @@ class NetworkingTests: XCTestCase {
 
     func testBasicAuthenticationHeaderField() {
         let networking = Networking(baseURL: baseURL)
-        networking.basicAuthenticationHeaderField = (username: "user", password: "passwd")
-        networking.GET("/basic-auth/user/passwd") { JSON, error in
+        networking.setBasicAuthenticationHeader(username: "user", password: "s3cr3t")
+        networking.GET("/basic-auth/user/s3cr3t") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let user = JSON["user"] as? String
             let authenticated = JSON["authenticated"] as? Bool
@@ -65,7 +65,7 @@ class NetworkingTests: XCTestCase {
     func testAuthenticationHeaderFieldValue() {
         let networking = Networking(baseURL: baseURL)
         let token = "hi-mom"
-        networking.authenticationHeaderFieldValue = "Bearer \(token)"
+        networking.bearerTokenAuthenticationHeader = token
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
@@ -79,7 +79,7 @@ class NetworkingTests: XCTestCase {
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
-            XCTAssertEqual("HeaderValue", headers?["HeaderKey"] as? String)
+            XCTAssertEqual("HeaderValue", headers?["Headerkey"] as? String)
         }
     }
 

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -6,7 +6,7 @@ class NetworkingTests: XCTestCase {
 
     func testBasicAuth() {
         let networking = Networking(baseURL: baseURL)
-        networking.authenticate(username: "user", password: "passwd")
+        networking.addBasicAuthenticationField(username: "user", password: "passwd")
         networking.GET("/basic-auth/user/passwd") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let user = JSON["user"] as? String
@@ -19,7 +19,7 @@ class NetworkingTests: XCTestCase {
     func testBearerTokenAuth() {
         let networking = Networking(baseURL: baseURL)
         let token = "hi-mom"
-        networking.authenticate(token: token)
+        networking.addBasicAuthenticationField(token: token)
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
@@ -30,7 +30,7 @@ class NetworkingTests: XCTestCase {
     func testCustomAuthorizationHeaderValue() {
         let networking = Networking(baseURL: baseURL)
         let value = "hi-mom"
-        networking.authenticate(headerValue: value)
+        networking.addBasicAuthenticationHeader(headerValue: value)
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
@@ -42,7 +42,7 @@ class NetworkingTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let key = "Anonymous-Token"
         let value = "hi-mom"
-        networking.authenticate(headerKey: key, headerValue: value)
+        networking.addBasicAuthenticationHeader(headerKey: key, headerValue: value)
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -50,10 +50,10 @@ class NetworkingTests: XCTestCase {
         }
     }
 
-    func testBasicAuthenticationHeaderField() {
+    func testSetAuthorizationHeaderWithUsernameAndPassword() {
         let networking = Networking(baseURL: baseURL)
-        networking.setBasicAuthenticationHeader(username: "user", password: "s3cr3t")
-        networking.GET("/basic-auth/user/s3cr3t") { JSON, error in
+        networking.setAuthorizationHeader(username: "user", password: "passwd")
+        networking.GET("/basic-auth/user/passwd") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let user = JSON["user"] as? String
             let authenticated = JSON["authenticated"] as? Bool
@@ -62,10 +62,10 @@ class NetworkingTests: XCTestCase {
         }
     }
 
-    func testAuthenticationHeaderFieldValue() {
+    func testSetAuthorizationHeaderWithBearerToken() {
         let networking = Networking(baseURL: baseURL)
         let token = "hi-mom"
-        networking.bearerTokenAuthenticationHeader = token
+        networking.setAuthorizationHeader(token: token)
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
@@ -73,13 +73,26 @@ class NetworkingTests: XCTestCase {
         }
     }
 
-    func testHeaderField() {
+    func setAuthorizationHeaderCustomValue() {
         let networking = Networking(baseURL: baseURL)
-        networking.headerFields = ["HeaderKey": "HeaderValue"]
+        let value = "hi-mom"
+        networking.setAuthorizationHeader(headerValue: value)
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
-            XCTAssertEqual("HeaderValue", headers?["Headerkey"] as? String)
+            XCTAssertEqual(value, headers?["Authorization"] as? String)
+        }
+    }
+
+    func setAuthorizationHeaderCustomHeaderKeyAndValue() {
+        let networking = Networking(baseURL: baseURL)
+        let key = "Anonymous-Token"
+        let value = "hi-mom"
+        networking.setAuthorizationHeader(headerKey: key, headerValue: value)
+        networking.POST("/post") { JSON, error in
+            guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
+            let headers = JSON["headers"] as? [String: Any]
+            XCTAssertEqual(value, headers?[key] as? String)
         }
     }
 

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -4,9 +4,9 @@ import XCTest
 class NetworkingTests: XCTestCase {
     let baseURL = "http://httpbin.org"
 
-    func testBasicAuth() {
+    func testBasicAuthenticationHeaderField() {
         let networking = Networking(baseURL: baseURL)
-        networking.addBasicAuthenticationField(username: "user", password: "passwd")
+        networking.basicAuthenticationHeaderField = (username: "user", password: "passwd")
         networking.GET("/basic-auth/user/passwd") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let user = JSON["user"] as? String
@@ -16,10 +16,10 @@ class NetworkingTests: XCTestCase {
         }
     }
 
-    func testBearerTokenAuth() {
+    func testAuthenticationHeaderFieldValue() {
         let networking = Networking(baseURL: baseURL)
         let token = "hi-mom"
-        networking.addBasicAuthenticationField(token: token)
+        networking.authenticationHeaderFieldValue = "Bearer \(token)"
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
@@ -27,26 +27,13 @@ class NetworkingTests: XCTestCase {
         }
     }
 
-    func testCustomAuthorizationHeaderValue() {
+    func testHeaderField() {
         let networking = Networking(baseURL: baseURL)
-        let value = "hi-mom"
-        networking.addBasicAuthenticationHeader(headerValue: value)
+        networking.headerFields = ["HeaderKey": "HeaderValue"]
         networking.POST("/post") { JSON, error in
             guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
             let headers = JSON["headers"] as? [String: Any]
-            XCTAssertEqual(value, headers?["Authorization"] as? String)
-        }
-    }
-
-    func testCustomAuthorizationHeaderValueAndHeaderKey() {
-        let networking = Networking(baseURL: baseURL)
-        let key = "Anonymous-Token"
-        let value = "hi-mom"
-        networking.addBasicAuthenticationHeader(headerKey: key, headerValue: value)
-        networking.POST("/post") { JSON, error in
-            guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
-            let headers = JSON["headers"] as? [String: Any]
-            XCTAssertEqual(value, headers?[key] as? String)
+            XCTAssertEqual("HeaderValue", headers?["HeaderKey"] as? String)
         }
     }
 

--- a/Tests/POSTTests.swift
+++ b/Tests/POSTTests.swift
@@ -219,7 +219,7 @@ class POSTTests: XCTestCase {
     }
 
     func deleteAllCloudinaryPhotos(networking: Networking, cloudName: String, secret: String, APIKey: String) {
-        networking.setBasicAuthenticationHeader(username: APIKey, password: secret)
+        networking.setAuthorizationHeader(username: APIKey, password: secret)
         networking.DELETE("/v1_1/\(cloudName)/resources/image/upload?all=true") { JSON, error in }
     }
 }

--- a/Tests/POSTTests.swift
+++ b/Tests/POSTTests.swift
@@ -219,7 +219,7 @@ class POSTTests: XCTestCase {
     }
 
     func deleteAllCloudinaryPhotos(networking: Networking, cloudName: String, secret: String, APIKey: String) {
-        networking.authenticate(username: APIKey, password: secret)
+        networking.addBasicAuthenticationField(username: APIKey, password: secret)
         networking.DELETE("/v1_1/\(cloudName)/resources/image/upload?all=true") { JSON, error in }
     }
 }

--- a/Tests/POSTTests.swift
+++ b/Tests/POSTTests.swift
@@ -219,7 +219,7 @@ class POSTTests: XCTestCase {
     }
 
     func deleteAllCloudinaryPhotos(networking: Networking, cloudName: String, secret: String, APIKey: String) {
-        networking.addBasicAuthenticationField(username: APIKey, password: secret)
+        networking.basicAuthenticationHeaderField = (APIKey, secret)
         networking.DELETE("/v1_1/\(cloudName)/resources/image/upload?all=true") { JSON, error in }
     }
 }

--- a/Tests/POSTTests.swift
+++ b/Tests/POSTTests.swift
@@ -219,7 +219,7 @@ class POSTTests: XCTestCase {
     }
 
     func deleteAllCloudinaryPhotos(networking: Networking, cloudName: String, secret: String, APIKey: String) {
-        networking.basicAuthenticationHeaderField = (APIKey, secret)
+        networking.setBasicAuthenticationHeader(username: APIKey, password: secret)
         networking.DELETE("/v1_1/\(cloudName)/resources/image/upload?all=true") { JSON, error in }
     }
 }


### PR DESCRIPTION
# Deprecates
```swift
public func authenticate(username: String, password: String)
public func authenticate(token: String)
public func authenticate(headerKey: String = "Authorization", headerValue: String)
```

# Adds
```swift
public func setAuthorizationHeader(username: String, password: String)
public func setAuthorizationHeader(token: String)
public func setAuthorizationHeader(headerKey: String = "Authorization", headerValue: String)
```