### PR TITLE
Fix issues related to special characters

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -122,6 +122,9 @@
 		14D144E11CEED63B00048629 /* FormDataPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D144DD1CEED63B00048629 /* FormDataPart.swift */; };
 		14D144E21CEED63B00048629 /* FormDataPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D144DD1CEED63B00048629 /* FormDataPart.swift */; };
 		14D144E31CEED63B00048629 /* FormDataPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D144DD1CEED63B00048629 /* FormDataPart.swift */; };
+		4496E8E61DAFB27A0092254E /* String+UTF8Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4496E8E51DAFB27A0092254E /* String+UTF8Tests.swift */; };
+		4496E8E71DAFB27A0092254E /* String+UTF8Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4496E8E51DAFB27A0092254E /* String+UTF8Tests.swift */; };
+		4496E8E81DAFB27A0092254E /* String+UTF8Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4496E8E51DAFB27A0092254E /* String+UTF8Tests.swift */; };
 		44B5D38A1D19B9E5004378B9 /* TestCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1474C1C21CA2988900E15D84 /* TestCheck.swift */; };
 		44B5D38B1D19B9E5004378B9 /* ImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1413F4631CE7963700482096 /* ImageTests.swift */; };
 		44B5D38C1D19B9E5004378B9 /* Dictionary+FormURLEncodedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1413F45E1CE7963700482096 /* Dictionary+FormURLEncodedTests.swift */; };
@@ -219,6 +222,7 @@
 		14D144DD1CEED63B00048629 /* FormDataPart.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormDataPart.swift; sourceTree = "<group>"; };
 		14DE34781CA298ED009B2E35 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		449687B41D1A433A000CF016 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4496E8E51DAFB27A0092254E /* String+UTF8Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+UTF8Tests.swift"; sourceTree = "<group>"; };
 		44B5D3AB1D19B9E5004378B9 /* tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tvOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		44B5D3AE1D19BA66004378B9 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		44DFD38D1D9A2D5A0014E9F2 /* iOSDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -303,8 +307,9 @@
 				146EF90D1CEBCEA50059DDB1 /* DELETETests.swift */,
 				1413F4631CE7963700482096 /* ImageTests.swift */,
 				1413F4641CE7963700482096 /* NetworkingTests.swift */,
-				1488E23C1CF138D700C6FBA3 /* SHA1.h */,
 				1488E23D1CF138D700C6FBA3 /* SHA1.m */,
+				1488E23C1CF138D700C6FBA3 /* SHA1.h */,
+				4496E8E51DAFB27A0092254E /* String+UTF8Tests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -854,6 +859,7 @@
 				1413F4761CE7968B00482096 /* Dictionary+FormURLEncoded.swift in Sources */,
 				146EF9181CEBCEA50059DDB1 /* PUTTests.swift in Sources */,
 				1413F47B1CE7969900482096 /* Networking+Image.swift in Sources */,
+				4496E8E81DAFB27A0092254E /* String+UTF8Tests.swift in Sources */,
 				14D144DF1CEED63B00048629 /* FormDataPart.swift in Sources */,
 				146EF9121CEBCEA50059DDB1 /* DELETETests.swift in Sources */,
 				1413F46D1CE7963700482096 /* Helpers.swift in Sources */,
@@ -968,6 +974,7 @@
 				1474C1C51CA2988900E15D84 /* NetworkActivityIndicator.swift in Sources */,
 				146EF9171CEBCEA50059DDB1 /* PUTTests.swift in Sources */,
 				1474C1C31CA2988900E15D84 /* Dictionary+FormURLEncoded.swift in Sources */,
+				4496E8E61DAFB27A0092254E /* String+UTF8Tests.swift in Sources */,
 				146EF9111CEBCEA50059DDB1 /* DELETETests.swift in Sources */,
 				14D144DE1CEED63B00048629 /* FormDataPart.swift in Sources */,
 				1413F46C1CE7963700482096 /* Helpers.swift in Sources */,
@@ -998,6 +1005,7 @@
 				44B5D3941D19B9E5004378B9 /* NetworkActivityIndicator.swift in Sources */,
 				44B5D3951D19B9E5004378B9 /* PUTTests.swift in Sources */,
 				44B5D3961D19B9E5004378B9 /* Dictionary+FormURLEncoded.swift in Sources */,
+				4496E8E71DAFB27A0092254E /* String+UTF8Tests.swift in Sources */,
 				44B5D3971D19B9E5004378B9 /* DELETETests.swift in Sources */,
 				44B5D3981D19B9E5004378B9 /* FormDataPart.swift in Sources */,
 				44B5D3991D19B9E5004378B9 /* Helpers.swift in Sources */,

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -201,7 +201,8 @@ public class Networking {
      - returns: A NSURL where a resource has been stored.
      */
     public func destinationURL(for path: String, cacheName: String? = nil) throws -> URL {
-        let resourcesPath = cacheName ?? self.url(for: path).absoluteString
+        let normalizedCacheName = cacheName?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+        let resourcesPath = normalizedCacheName ?? self.url(for: path).absoluteString
         let normalizedResourcesPath = resourcesPath.replacingOccurrences(of: "/", with: "-")
         let folderPath = Networking.domain
         let finalPath = "\(folderPath)/\(normalizedResourcesPath)"

--- a/Sources/String+UTF8.swift
+++ b/Sources/String+UTF8.swift
@@ -12,7 +12,7 @@ extension String {
             let lastComponentAsString = lastComponent.map { String($0) }.reduce("", +)
             if let rangeOfLastComponent = self.range(of: lastComponentAsString) {
                 let stringWithoutLastComponent = self.substring(to: rangeOfLastComponent.lowerBound)
-                if let lastComponentEncoded = lastComponentAsString.addingPercentEncoding(withAllowedCharacters: CharacterSet.alphanumerics) {
+                if let lastComponentEncoded = lastComponentAsString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
                     let encodedString = stringWithoutLastComponent + lastComponentEncoded
                     return encodedString
                 }

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -83,6 +83,20 @@ class NetworkingTests: XCTestCase {
         XCTAssertEqual(destinationURL.lastPathComponent, "http:--httpbin.org-image-png")
     }
 
+    func testDestinationURLWithSpecialCharactersInPath() {
+        let networking = Networking(baseURL: baseURL)
+        let path = "/h�sttur.jpg"
+        guard let destinationURL = try? networking.destinationURL(for: path) else { XCTFail(); return }
+        XCTAssertEqual(destinationURL.lastPathComponent, "http:--httpbin.org-h%EF%BF%BDsttur.jpg")
+    }
+
+    func testDestinationURLWithSpecialCharactersInCacheName() {
+        let networking = Networking(baseURL: baseURL)
+        let path = "/the-url-doesnt-really-matter"
+        guard let destinationURL = try? networking.destinationURL(for: path, cacheName: "h�sttur.jpg-25-03/small") else { XCTFail(); return }
+        XCTAssertEqual(destinationURL.lastPathComponent, "h%EF%BF%BDsttur.jpg-25-03-small")
+    }
+
     func testDestinationURLCache() {
         let networking = Networking(baseURL: baseURL)
         let path = "/image/png"

--- a/Tests/String+UTF8Tests.swift
+++ b/Tests/String+UTF8Tests.swift
@@ -1,0 +1,9 @@
+import Foundation
+import XCTest
+
+class String_UTF8Tests: XCTestCase {
+    func testEncodeUTF8WithNorwegianCharacters() {
+        let encodedString = "døgnvillburgere.jpg".encodeUTF8()
+        XCTAssertEqual(encodedString, "d%C3%B8gnvillburgere.jpg")
+    }
+}


### PR DESCRIPTION
If you provided a path that contained special characters, calling destination URL would crash.