### PR TITLE
Make public to cancel a single request and add a unit test

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -282,7 +282,7 @@ public class Networking {
      - parameter requestID: The ID of the request to be cancelled.
      - parameter completion: The completion block to be called when the request is cancelled.
      */
-    func cancel(with requestID: String, completion: ((Void) -> Void)? = nil) {
+    public func cancel(with requestID: String, completion: ((Void) -> Void)? = nil) {
         self.session.getTasksWithCompletionHandler { dataTasks, uploadTasks, downloadTasks in
             var tasks = [URLSessionTask]()
             tasks.append(contentsOf: dataTasks as [URLSessionTask])

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -171,8 +171,28 @@ class NetworkingTests: XCTestCase {
         XCTAssertEqual(relativePath2, "/basic-auth/user/passwd")
     }
 
-    func testCancelRequests() {
-        let expectation = self.expectation(description: "testCancelRequests")
+    func testCancelWithRequestID() {
+        let expectation = self.expectation(description: "testCancelAllRequests")
+        let networking = Networking(baseURL: baseURL)
+        networking.disableTestingMode = true
+        var cancelledGET = false
+
+        let requestID = networking.GET("/get") { JSON, error in
+            cancelledGET = error?.code == -999
+            XCTAssertTrue(cancelledGET)
+
+            if cancelledGET {
+                expectation.fulfill()
+            }
+        }
+
+        networking.cancel(with: requestID, completion: nil)
+
+        self.waitForExpectations(timeout: 15.0, handler: nil)
+    }
+
+    func testCancelAllRequests() {
+        let expectation = self.expectation(description: "testCancelAllRequests")
         let networking = Networking(baseURL: baseURL)
         networking.disableTestingMode = true
         var cancelledGET = false


### PR DESCRIPTION
## Adds support for cancelling a single request using a requestID

```swift
let networking = Networking(baseURL: baseURL)
let requestID = networking.GET("/get") { JSON, error in
     //....
}
networking.cancel(with: requestID, completion: nil)
```