### PR TITLE
Add support for setting header fields

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -175,6 +175,11 @@ public class Networking {
     }
 
     /** 
+     Sets the header fields for every HTTP call.
+     */
+    public var headerFields: [String: String]?
+
+    /** 
      Authenticates using a custom HTTP Authorization header.
      - parameter authorizationHeaderKey: Sets this value as the key for the HTTP `Authorization` header
      - parameter authorizationHeaderValue: Sets this value to the HTTP `Authorization` header or to the `headerKey` if you provided that.
@@ -535,6 +540,12 @@ extension Networking {
             request.setValue(authorizationHeader, forHTTPHeaderField: self.authorizationHeaderKey)
         } else if let token = self.token {
             request.setValue("Bearer \(token)", forHTTPHeaderField: self.authorizationHeaderKey)
+        }
+
+        if let headerFields = self.headerFields {
+            for (key, value) in headerFields {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
         }
 
         DispatchQueue.main.async {

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -96,6 +96,16 @@ class NetworkingTests: XCTestCase {
         }
     }
 
+    func testHeaderField() {
+        let networking = Networking(baseURL: baseURL)
+        networking.headerFields = ["HeaderKey": "HeaderValue"]
+        networking.POST("/post") { JSON, error in
+            guard let JSON = JSON as? [String: Any] else { XCTFail(); return }
+            let headers = JSON["headers"] as? [String: Any]
+            XCTAssertEqual("HeaderValue", headers?["Headerkey"] as? String)
+        }
+    }
+
     func testURLForPath() {
         let networking = Networking(baseURL: baseURL)
         let url = networking.url(for: "/hello")


### PR DESCRIPTION
## Adds support for setting custom header fields

```swift 
let networking = Networking(baseURL: baseURL)
networking.headerFields = ["HeaderKey": "HeaderValue"]
networking.POST("/post") { JSON, error in
    //.....
}
```

Fixes https://github.com/3lvis/Networking/issues/138