### PR TITLE
Use URLError.Code for cancelled request instead of -999

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,12 +249,12 @@ networking.POST("/upload", parameterType: .Custom("application/octet-stream"), p
 
 ### Using path
 
-Cancelling any request for a specific path is really simple. Beware that cancelling a request will cause the request to return with an error with status code -999.
+Cancelling any request for a specific path is really simple. Beware that cancelling a request will cause the request to return with an error with status code URLError.cancelled.
 
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
 networking.GET("/get") { JSON, error in
-    // Cancelling a GET request returns an error with code -999 which means cancelled request
+    // Cancelling a GET request returns an error with code URLError.cancelled which means cancelled request
 }
 
 networking.cancelGET("/get")
@@ -335,7 +335,7 @@ networking.downloadImage("/image/png") { image, error in
 ```swift
 let networking = Networking(baseURL: baseURL)
 networking.downloadImage("/image/png") { image, error in
-    // Cancelling a image download returns an error with code -999 which means cancelled request
+    // Cancelling a image download returns an error with code URLError.cancelled which means cancelled request
 }
 
 networking.cancelImageDownload("/image/png")

--- a/Sources/Networking+DELETE.swift
+++ b/Sources/Networking+DELETE.swift
@@ -51,7 +51,7 @@ public extension Networking {
     }
 
     /**
-     Cancels the DELETE request for the specified path. This causes the request to complete with error code -999.
+     Cancels the DELETE request for the specified path. This causes the request to complete with error code URLError.cancelled.
      - parameter path: The path for the cancelled DELETE request.
      - parameter completion: A closure that gets called when the cancellation is completed.
      */

--- a/Sources/Networking+GET.swift
+++ b/Sources/Networking+GET.swift
@@ -51,7 +51,7 @@ public extension Networking {
     }
 
     /**
-     Cancels the GET request for the specified path. This causes the request to complete with error code -999.
+     Cancels the GET request for the specified path. This causes the request to complete with error code URLError.cancelled.
      - parameter path: The path for the cancelled GET request
      - parameter completion: A closure that gets called when the cancellation is completed.
      */

--- a/Sources/Networking+Image.swift
+++ b/Sources/Networking+Image.swift
@@ -43,7 +43,7 @@ public extension Networking {
     }
 
     /**
-     Cancels the image download request for the specified path. This causes the request to complete with error code -999.
+     Cancels the image download request for the specified path. This causes the request to complete with error code URLError.cancelled.
      - parameter path: The path for the cancelled image download request.
      - parameter completion: A closure that gets called when the cancellation is completed.
      */

--- a/Sources/Networking+POST.swift
+++ b/Sources/Networking+POST.swift
@@ -85,7 +85,7 @@ public extension Networking {
     }
 
     /**
-     Cancels the POST request for the specified path. This causes the request to complete with error code -999.
+     Cancels the POST request for the specified path. This causes the request to complete with error code URLError.cancelled.
      - parameter path: The path for the cancelled POST request.
      - parameter completion: A closure that gets called when the cancellation is completed.
      */

--- a/Sources/Networking+PUT.swift
+++ b/Sources/Networking+PUT.swift
@@ -53,7 +53,7 @@ public extension Networking {
     }
 
     /**
-     Cancels the PUT request for the specified path. This causes the request to complete with error code -999.
+     Cancels the PUT request for the specified path. This causes the request to complete with error code URLError.cancelled.
      - parameter path: The path for the cancelled PUT request.
      - parameter completion: A closure that gets called when the cancellation is completed.
      */

--- a/Tests/DELETETests.swift
+++ b/Tests/DELETETests.swift
@@ -91,7 +91,7 @@ class DELETETests: XCTestCase {
         var completed = false
         networking.DELETE("/delete") { JSON, error in
             XCTAssertTrue(completed)
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
 
@@ -110,7 +110,7 @@ class DELETETests: XCTestCase {
         var completed = false
         let requestID = networking.DELETE("/delete") { JSON, error in
             XCTAssertTrue(completed)
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
 

--- a/Tests/GETTests.swift
+++ b/Tests/GETTests.swift
@@ -121,7 +121,7 @@ class GETTests: XCTestCase {
         var completed = false
         networking.GET("/get") { JSON, error in
             XCTAssertTrue(completed)
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
 
@@ -140,7 +140,7 @@ class GETTests: XCTestCase {
         var completed = false
         let requestID = networking.GET("/get") { JSON, error in
             XCTAssertTrue(completed)
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
 

--- a/Tests/ImageTests.swift
+++ b/Tests/ImageTests.swift
@@ -134,7 +134,7 @@ class ImageTests: XCTestCase {
         Helper.removeFileIfNeeded(networking, path: path)
 
         networking.downloadImage(path) { image, error in
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
 

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -116,7 +116,7 @@ class NetworkingTests: XCTestCase {
     }
 
     func testStatusCodeType() {
-        XCTAssertEqual((-999).statusCodeType(), Networking.StatusCodeType.unknown)
+        XCTAssertEqual((URLError.cancelled.rawValue).statusCodeType(), Networking.StatusCodeType.cancelled)
         XCTAssertEqual(99.statusCodeType(), Networking.StatusCodeType.unknown)
         XCTAssertEqual(101.statusCodeType(), Networking.StatusCodeType.informational)
         XCTAssertEqual(203.statusCodeType(), Networking.StatusCodeType.successful)
@@ -142,7 +142,7 @@ class NetworkingTests: XCTestCase {
         var cancelledGET = false
 
         let requestID = networking.GET("/get") { JSON, error in
-            cancelledGET = error?.code == -999
+            cancelledGET = error?.code == URLError.cancelled.rawValue
             XCTAssertTrue(cancelledGET)
 
             if cancelledGET {
@@ -163,7 +163,7 @@ class NetworkingTests: XCTestCase {
         var cancelledPOST = false
 
         networking.GET("/get") { JSON, error in
-            cancelledGET = error?.code == -999
+            cancelledGET = error?.code == URLError.cancelled.rawValue
             XCTAssertTrue(cancelledGET)
 
             if cancelledGET && cancelledPOST {
@@ -172,7 +172,7 @@ class NetworkingTests: XCTestCase {
         }
 
         networking.POST("/post") { JSON, error in
-            cancelledPOST = error?.code == -999
+            cancelledPOST = error?.code == URLError.cancelled.rawValue
             XCTAssertTrue(cancelledPOST)
 
             if cancelledGET && cancelledPOST {
@@ -191,7 +191,7 @@ class NetworkingTests: XCTestCase {
         networking.disableTestingMode = true
         networking.GET("/get") { JSON, error in
             XCTAssertTrue(Thread.isMainThread)
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
         networking.cancelAllRequests(with: nil)

--- a/Tests/POSTTests.swift
+++ b/Tests/POSTTests.swift
@@ -206,7 +206,7 @@ class POSTTests: XCTestCase {
         var completed = false
         networking.POST("/post", parameters: ["username": "jameson", "password": "secret"]) { JSON, error in
             XCTAssertTrue(completed)
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
 
@@ -225,7 +225,7 @@ class POSTTests: XCTestCase {
         var completed = false
         let requestID = networking.POST("/post", parameters: ["username": "jameson", "password": "secret"]) { JSON, error in
             XCTAssertTrue(completed)
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
 

--- a/Tests/PUTTests.swift
+++ b/Tests/PUTTests.swift
@@ -92,7 +92,7 @@ class PUTTests: XCTestCase {
         var completed = false
         networking.PUT("/put", parameters: ["username": "jameson", "password": "secret"]) { JSON, error in
             XCTAssertTrue(completed)
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
 
@@ -111,7 +111,7 @@ class PUTTests: XCTestCase {
         var completed = false
         let requestID = networking.PUT("/put", parameters: ["username": "jameson", "password": "secret"]) { JSON, error in
             XCTAssertTrue(completed)
-            XCTAssertEqual(error?.code, -999)
+            XCTAssertEqual(error?.code, URLError.cancelled.rawValue)
             expectation.fulfill()
         }
 


### PR DESCRIPTION
As in `URLSessionTask` header:

```
/* -cancel returns immediately, but marks a task as being canceled.
     * The task will signal -URLSession:task:didCompleteWithError: with an
     * error value of { NSURLErrorDomain, NSURLErrorCancelled }.  In some 
     * cases, the task may signal other work before it acknowledges the 
     * cancelation.  -cancel may be sent to a task that has been suspended.
     */
```

when a task is cancelled, it will create a `NSError` with code `NSURLErrorCancelled`, which equals to `URLError.cancelled.rawValue`. 

So instead of use hard-coded value `-999` from `HTTPURLResponse.statusCode`, I think we can use `URLError.cancelled` because `-999` is not a standard HTTP status code and it is used only in Apple framework.

// I don't know anything about GitHub checks but all the Xcode tests are success.