### PR TITLE
Adding support for url encoded parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ networking.GET("/stories") { JSON, headers, error in
 }
 ```
 
+Similarly, adding parameters to a request (not necessarily a `GET`) is accomplished by using `addParameters`:
+
+```swift
+let networking = Networking(baseURL: "https://api-news.layervault.com/api/v2")
+let path = networking.addParameters(["count": 25], toPath: "/stories")
+networking.GET(path) { JSON, error in
+    // Stories JSON: https://api-news.layervault.com/api/v2/stories?count=25
+}
+```
+
 **POST example**:
 
 ```swift

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -242,6 +242,25 @@ public class Networking {
         guard let url = URL(string: self.baseURL + encodedPath) else { fatalError("Couldn't create a url using baseURL: \(self.baseURL) and encodedPath: \(encodedPath)") }
         return url
     }
+    
+    /**
+     Returns a new path String by appending the provided parameters as URL encoded query parameters to the given path.
+     - parameter parameters: The parameters to append to the path. Assumed to be a dictionary of [String: Any] where Any is convertible to a string.
+     - parameter path: The path to append the parameters to. The path may be a simple bare path, or may already have parameters added to it.
+     - returns: A String generated after appending the URL encoded parameters to the given path.
+     */
+    public func addParameters(_ parameters: [String: Any], toPath path: String) -> String {
+        let paramString = parameters.urlEncodedString()
+        if path.contains("?") {
+            if let lastChar = path.characters.last, lastChar == "?" {
+                return path + paramString
+            } else {
+                return path + "&" + paramString
+            }
+        } else {
+            return path + "?" + paramString
+        }
+    }
 
     /**
      Returns the NSURL used to store a resource for a certain path. Useful to find where a download image is located.

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -65,6 +65,13 @@ class NetworkingTests: XCTestCase {
         let url = networking.url(for: "/hello")
         XCTAssertEqual(url.absoluteString, "http://httpbin.org/hello")
     }
+    
+    func testURLForPathWithParameters() {
+        let networking = Networking(baseURL: baseURL)
+        let path = networking.addParameters(["count": 25], toPath: "/hello")
+        let url = networking.url(for: path)
+        XCTAssertEqual(url.absoluteString, "http://httpbin.org/hello?count=25")
+    }
 
     func testSkipTestMode() {
         let expectation = self.expectation(description: "testSkipTestMode")
@@ -237,5 +244,60 @@ class NetworkingTests: XCTestCase {
             Networking.deleteCachedFiles()
             XCTAssertFalse(FileManager.default.exists(at: folderURL))
         }
+    }
+    
+    func testAddingParametersToPathWithoutParameters() {
+        let networking = Networking(baseURL: self.baseURL)
+        let queryPath = "/profile"
+        let parameters = ["userId": 5]
+        
+        let path = networking.addParameters(parameters, toPath: queryPath)
+        
+        XCTAssertEqual(path, "/profile?userId=5")
+    }
+    
+    func testAddingParametersToPathWithoutExistingParameters() {
+        let networking = Networking(baseURL: self.baseURL)
+        let queryPath = "/profile?accountId=123"
+        let parameters = ["userId": 5]
+        
+        let path = networking.addParameters(parameters, toPath: queryPath)
+        
+        XCTAssertEqual(path, "/profile?accountId=123&userId=5")
+    }
+    
+    func testAddingParametersToPathWithExistingQuestion() {
+        let networking = Networking(baseURL: self.baseURL)
+        let queryPath = "/profile?"
+        let parameters = ["userId": 5]
+        
+        let path = networking.addParameters(parameters, toPath: queryPath)
+        
+        XCTAssertEqual(path, "/profile?userId=5")
+    }
+    
+    func testAddingParametersToPathWithPercentEncoding() {
+        let networking = Networking(baseURL: self.baseURL)
+        let queryPath = "/profile"
+        let parameters = ["name": "Elvis Nuñez"]
+        
+        let path = networking.addParameters(parameters, toPath: queryPath)
+        
+        XCTAssertEqual(path, "/profile?name=Elvis%20Nu%C3%B1ez")
+    }
+    
+    func testAddingMultipleParametersToPath() {
+        let networking = Networking(baseURL: self.baseURL)
+        let queryPath = "/profile"
+        let parameters: [String : Any] = ["userId": 5, "accountId": "ac3f"]
+        
+        let path = networking.addParameters(parameters, toPath: queryPath)
+        
+        XCTAssertTrue(path.contains("userId=5"))
+        XCTAssertTrue(path.contains("accountId=ac3f"))
+        XCTAssertTrue(path.contains("&"))
+        XCTAssertTrue(
+            path == "/profile?userId=5&accountId=ac3f" ||
+            path == "/profile?accountId=ac3f&userId=5")
     }
 }


### PR DESCRIPTION
As requested in #153, adding a simple method to ease adding parameters to URLs for any kind of request.

This is accomplished by adding a new function `addParameters` that leverages the pre-existing `urlEncodedString` extension on `Dictionary`. This minimal change should support any kind of request, and not simply `GET` requests. This design was chosen so as to minimize the surface area of API changes, and to preserve the existing behavior of caches, images, etc.

Documentation and tests are added. All tests still pass.

The updated documentation contains a simple use case using the proposed change:

```swift
let networking = Networking(baseURL: "https://api-news.layervault.com/api/v2")
let path = networking.addParameters(["count": 25], toPath: "/stories")
networking.GET(path) { JSON, error in
    // Stories JSON: https://api-news.layervault.com/api/v2/stories?count=25
}
```

Open to having a discussion on the design if anyone has differing opinions. 😀