### PR TITLE
Add error convenience accessor

### DIFF
--- a/Sources/Result.swift
+++ b/Sources/Result.swift
@@ -5,6 +5,15 @@ public enum JSONResult {
 
     case failure(FailureJSONResponse)
 
+    public var error: NSError? {
+        switch self {
+        case .success:
+            return nil
+        case .failure(let response):
+            return response.error
+        }
+    }
+
     public init(body: Any?, response: HTTPURLResponse, error: NSError?) {
         var json: JSON
         

--- a/Tests/ResulTests.swift
+++ b/Tests/ResulTests.swift
@@ -29,4 +29,16 @@ class ResultTests: XCTestCase {
             XCTAssertEqual(result.error.code, URLError.cannotParseResponse.rawValue)
         }
     }
+
+    func testJSONResponseError() {
+        let url = URL(string: "http://www.google.com")!
+        let urlResponse = HTTPURLResponse(url: url, statusCode: 200)
+
+        let nilErrorResult = JSONResult(body: [:], response: urlResponse, error: nil)
+        XCTAssertNil(nilErrorResult.error)
+
+        let error = NSError(domain: "", code: 0, userInfo: nil)
+        let errorResult = JSONResult(body: [:], response: urlResponse, error: error)
+        XCTAssertNotNil(errorResult.error)
+    }
 }


### PR DESCRIPTION
Useful for when you don't care about the result but more if there's an error or not.

Before:
```swift
networking.get("/somepath") { result in 
    switch result {
    case .success:
        completion(nil)
    case .failure(let response):
        completion(response.error)
    }
}
```

Now:

```swift
networking.get("/somepath") { result in 
    completion(result.error) // NSError?
}
```