### PR TITLE
Add support for caching level

### DIFF
--- a/Sources/Networking+HTTPRequests.swift
+++ b/Sources/Networking+HTTPRequests.swift
@@ -243,7 +243,7 @@ public extension Networking {
     ///   - cacheName: The cache name used to identify the downloaded image, by default the path is used.
     /// - Returns: The cached image.
     public func imageFromCache(_ path: String, cacheName: String? = nil) -> Image? {
-        let object = objectFromCache(for: path, cacheName: cacheName, responseType: .image)
+        let object = objectFromCache(for: path, cacheName: cacheName, cachingLevel: .memoryAndFile, responseType: .image)
 
         return object as? Image
     }
@@ -256,8 +256,8 @@ public extension Networking {
     ///   - completion: The result of the operation, it's an enum with two cases: success and failure.
     /// - Returns: The request identifier.
     @discardableResult
-    public func downloadImage(_ path: String, cacheName: String? = nil, completion: @escaping (_ result: ImageResult) -> Void) -> String {
-        return handleImageRequest(.get, path: path, cacheName: cacheName, responseType: .image, completion: completion)
+    public func downloadImage(_ path: String, cacheName: String? = nil, cachingLevel: CachingLevel = .memoryAndFile, completion: @escaping (_ result: ImageResult) -> Void) -> String {
+        return handleImageRequest(.get, path: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: .image, completion: completion)
     }
 
     /// Cancels the image download request for the specified path. This causes the request to complete with error code URLError.cancelled.
@@ -285,8 +285,8 @@ public extension Networking {
     ///   - cacheName: The cache name used to identify the downloaded data, by default the path is used.
     ///   - completion: A closure that gets called when the download request is completed, it contains  a `data` object and an `NSError`.
     @discardableResult
-    public func downloadData(_ path: String, cacheName: String? = nil, completion: @escaping (_ result: DataResult) -> Void) -> String {
-        return handleDataRequest(.get, path: path, cacheName: cacheName, responseType: .data, completion: completion)
+    public func downloadData(_ path: String, cacheName: String? = nil, cachingLevel: CachingLevel = .memoryAndFile, completion: @escaping (_ result: DataResult) -> Void) -> String {
+        return handleDataRequest(.get, path: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: .data, completion: completion)
     }
 
     /// Retrieves data from the cache or from the filesystem.
@@ -296,7 +296,7 @@ public extension Networking {
     ///   - cacheName: The cache name used to identify the downloaded data, by default the path is used.
     /// - Returns: The cached data.
     public func dataFromCache(_ path: String, cacheName: String? = nil) -> Data? {
-        let object = objectFromCache(for: path, cacheName: cacheName, responseType: .data)
+        let object = objectFromCache(for: path, cacheName: cacheName, cachingLevel: .memoryAndFile, responseType: .data)
 
         return object as? Data
     }

--- a/Sources/Networking+Private.swift
+++ b/Sources/Networking+Private.swift
@@ -2,29 +2,38 @@ import Foundation
 
 extension Networking {
 
-    func objectFromCache(for path: String, cacheName: String?, responseType: ResponseType) -> Any? {
+    func objectFromCache(for path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) -> Any? {
         /// Workaround: Remove URL parameters from path. That can lead to writing cached files with names longer than
         /// 255 characters, resulting in error. Another option to explore is to use a hash version of the url if it's
         /// longer than 255 characters.
         guard let destinationURL = try? destinationURL(for: path, cacheName: cacheName) else { fatalError("Couldn't get destination URL for path: \(path) and cacheName: \(String(describing: cacheName))") }
 
-        if let object = cache.object(forKey: destinationURL.absoluteString as AnyObject) {
-            return object
-        } else if FileManager.default.exists(at: destinationURL) {
-            var returnedObject: Any?
+        switch cachingLevel {
+        case .memory:
+            try? FileManager.default.remove(at: destinationURL)
+            return cache.object(forKey: destinationURL.absoluteString as AnyObject)
+        case .memoryAndFile:
+            if let object = cache.object(forKey: destinationURL.absoluteString as AnyObject) {
+                return object
+            } else if FileManager.default.exists(at: destinationURL) {
+                var returnedObject: Any?
 
-            let object = destinationURL.getData()
-            if responseType == .image {
-                returnedObject = Image(data: object)
+                let object = destinationURL.getData()
+                if responseType == .image {
+                    returnedObject = Image(data: object)
+                } else {
+                    returnedObject = object
+                }
+                if let returnedObject = returnedObject {
+                    cache.setObject(returnedObject as AnyObject, forKey: destinationURL.absoluteString as AnyObject)
+                }
+
+                return returnedObject
             } else {
-                returnedObject = object
+                return nil
             }
-            if let returnedObject = returnedObject {
-                cache.setObject(returnedObject as AnyObject, forKey: destinationURL.absoluteString as AnyObject)
-            }
-
-            return returnedObject
-        } else {
+        case .none:
+            try? FileManager.default.remove(at: destinationURL)
             return nil
         }
     }
@@ -83,13 +92,13 @@ extension Networking {
         }
     }
 
-    func handleDataRequest(_ requestType: RequestType, path: String, cacheName: String?, responseType: ResponseType, completion: @escaping (_ result: DataResult) -> Void) -> String {
+    func handleDataRequest(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType, completion: @escaping (_ result: DataResult) -> Void) -> String {
         if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
             return handleFakeRequest(fakeRequest, path: path) { _, response, error in
                 completion(DataResult(body: fakeRequest.response, response: response, error: error))
             }
         } else {
-            let object = objectFromCache(for: path, cacheName: cacheName, responseType: responseType)
+            let object = objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType)
             if let object = object {
                 TestCheck.testBlock(isSynchronous) {
                     let url = try! self.composedURL(with: path)
@@ -105,8 +114,15 @@ extension Networking {
                     }
 
                     if let data = data, data.count > 0 {
-                        _ = try? data.write(to: destinationURL, options: [.atomic])
-                        self.cache.setObject(data as AnyObject, forKey: destinationURL.absoluteString as AnyObject)
+                        switch cachingLevel {
+                        case .memory:
+                            self.cache.setObject(data as AnyObject, forKey: destinationURL.absoluteString as AnyObject)
+                        case .memoryAndFile:
+                            _ = try? data.write(to: destinationURL, options: [.atomic])
+                            self.cache.setObject(data as AnyObject, forKey: destinationURL.absoluteString as AnyObject)
+                        case .none:
+                            break
+                        }
                     } else {
                         self.cache.removeObject(forKey: destinationURL.absoluteString as AnyObject)
                     }
@@ -119,13 +135,13 @@ extension Networking {
         }
     }
 
-    func handleImageRequest(_ requestType: RequestType, path: String, cacheName: String?, responseType: ResponseType, completion: @escaping (_ result: ImageResult) -> Void) -> String {
+    func handleImageRequest(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType, completion: @escaping (_ result: ImageResult) -> Void) -> String {
         if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
             return handleFakeRequest(fakeRequest, path: path) { _, response, error in
                 completion(ImageResult(body: fakeRequest.response, response: response, error: error))
             }
         } else {
-            let object = objectFromCache(for: path, cacheName: cacheName, responseType: responseType)
+            let object = objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType)
             if let object = object {
                 TestCheck.testBlock(isSynchronous) {
                     let url = try! self.composedURL(with: path)
@@ -143,9 +159,17 @@ extension Networking {
 
                     var returnedImage: Image?
                     if let data = data, data.count > 0, let image = Image(data: data) {
-                        _ = try? data.write(to: destinationURL, options: [.atomic])
+                        switch cachingLevel {
+                        case .memory:
+                            self.cache.setObject(image, forKey: destinationURL.absoluteString as AnyObject)
+                        case .memoryAndFile:
+                            _ = try? data.write(to: destinationURL, options: [.atomic])
+                            self.cache.setObject(image, forKey: destinationURL.absoluteString as AnyObject)
+                        case .none:
+                            break
+                        }
+
                         returnedImage = image
-                        self.cache.setObject(image, forKey: destinationURL.absoluteString as AnyObject)
                     } else {
                         self.cache.removeObject(forKey: destinationURL.absoluteString as AnyObject)
                     }

--- a/Sources/Networking+Private.swift
+++ b/Sources/Networking+Private.swift
@@ -33,6 +33,7 @@ extension Networking {
                 return nil
             }
         case .none:
+            cache.removeObject(forKey: destinationURL.absoluteString as AnyObject)
             try? FileManager.default.remove(at: destinationURL)
             return nil
         }

--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -111,6 +111,13 @@ open class Networking {
         URLSession(configuration: self.configuration)
     }()
 
+    /// Caching options
+    public enum CachingLevel {
+        case memory
+        case memoryAndFile
+        case none
+    }
+
     /// Base initializer, it creates an instance of `Networking`.
     ///
     /// - Parameters:

--- a/iOSDemo/FakeImageController.swift
+++ b/iOSDemo/FakeImageController.swift
@@ -11,8 +11,8 @@ class FakeImageController: UIViewController {
     lazy var networking: Networking = {
         let networking = Networking(baseURL: "http://httpbin.org")
 
-        let image = UIImage(named: "pig.png")
-        networking.fakeImageDownload("/pig", image: image)
+        // let image = UIImage(named: "pig.png")
+        // networking.fakeImageDownload("/image/png", image: image)
 
         return networking
     }()
@@ -27,7 +27,7 @@ class FakeImageController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        networking.downloadImage("/pig") { result in
+        networking.downloadImage("/image/png") { result in
             switch result {
             case let .success(response):
                 self.imageView.image = response.image

--- a/iOSDemo/Info.plist
+++ b/iOSDemo/Info.plist
@@ -26,6 +26,11 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Allows the user to disable caching per request.

```swift
networking.downloadImage("/image/png", cachingLevel: .none) { result in
    // Non-cached image....
}
```