### PR TITLE
Add support for skipping initializing with a url

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -124,7 +124,7 @@ open class Networking {
     ///   - baseURL: The base URL for HTTP requests under `Networking`.
     ///   - configuration: The URLSessionConfiguration configuration to be used
     ///   - cache: The NSCache to use, it has a built-in default one.
-    public init(baseURL: String, configuration: URLSessionConfiguration = .default, cache: NSCache<AnyObject, AnyObject>? = nil) {
+    public init(baseURL: String = "", configuration: URLSessionConfiguration = .default, cache: NSCache<AnyObject, AnyObject>? = nil) {
         self.baseURL = baseURL
         self.configuration = configuration
         self.cache = cache ?? NSCache()

--- a/Tests/GETTests.swift
+++ b/Tests/GETTests.swift
@@ -44,6 +44,25 @@ class GETTests: XCTestCase {
         }
     }
 
+    func testGETWithFullPath() {
+        let networking = Networking()
+        networking.get("http://httpbin.org/get") { result in
+            switch result {
+            case let .success(response):
+                let json = response.dictionaryBody
+
+                guard let url = json["url"] as? String else { XCTFail(); return }
+                XCTAssertEqual(url, "http://httpbin.org/get")
+
+                guard let headers = json["headers"] as? [String: String] else { XCTFail(); return }
+                let contentType = headers["Content-Type"]
+                XCTAssertNil(contentType)
+            case .failure:
+                XCTFail()
+            }
+        }
+    }
+
     func testGETWithHeaders() {
         let networking = Networking(baseURL: baseURL)
         networking.get("/get") { result in

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -91,6 +91,12 @@ class NetworkingTests: XCTestCase {
         XCTAssertEqual(url.absoluteString, "http://httpbin.org/hello")
     }
 
+    func testURLForPathWithFullPath() {
+        let networking = Networking()
+        let url = try! networking.composedURL(with: "http://httpbin.org/hello")
+        XCTAssertEqual(url.absoluteString, "http://httpbin.org/hello")
+    }
+
     func testSkipTestMode() {
         let expectation = self.expectation(description: "testSkipTestMode")
 
@@ -114,6 +120,13 @@ class NetworkingTests: XCTestCase {
     func testDestinationURL() {
         let networking = Networking(baseURL: baseURL)
         let path = "/image/png"
+        guard let destinationURL = try? networking.destinationURL(for: path) else { XCTFail(); return }
+        XCTAssertEqual(destinationURL.lastPathComponent, "http:--httpbin.org-image-png")
+    }
+
+    func testDestinationURLWithFullPath() {
+        let networking = Networking()
+        let path = "http://httpbin.org/image/png"
         guard let destinationURL = try? networking.destinationURL(for: path) else { XCTFail(); return }
         XCTAssertEqual(destinationURL.lastPathComponent, "http:--httpbin.org-image-png")
     }


### PR DESCRIPTION
Now you can do:

```swift
let networking = Networking()
networking.get("http://httpbin.org/get") { result in
    // ....
}
```