### PR TITLE
Always using caches directory for caching (#238)

### DIFF
--- a/Sources/Networking.swift
+++ b/Sources/Networking.swift
@@ -296,11 +296,7 @@ open class Networking {
 
     /// Deletes the downloaded/cached files.
     public static func deleteCachedFiles() {
-        #if os(tvOS)
         let directory = FileManager.SearchPathDirectory.cachesDirectory
-        #else
-        let directory = TestCheck.isTesting ? FileManager.SearchPathDirectory.cachesDirectory : FileManager.SearchPathDirectory.documentDirectory
-        #endif
         if let cachesURL = FileManager.default.urls(for: directory, in: .userDomainMask).first {
             let folderURL = cachesURL.appendingPathComponent(URL(string: Networking.domain)!.absoluteString)
             if FileManager.default.exists(at: folderURL) {

--- a/Tests/NetworkingTests.swift
+++ b/Tests/NetworkingTests.swift
@@ -281,11 +281,7 @@ class NetworkingTests: XCTestCase {
     }
 
     func testDeleteCachedFiles() {
-        #if os(tvOS)
         let directory = FileManager.SearchPathDirectory.cachesDirectory
-        #else
-        let directory = TestCheck.isTesting ? FileManager.SearchPathDirectory.cachesDirectory : FileManager.SearchPathDirectory.documentDirectory
-        #endif
         let cachesURL = FileManager.default.urls(for: directory, in: .userDomainMask).first!
         let folderURL = cachesURL.appendingPathComponent(URL(string: Networking.domain)!.absoluteString)
 


### PR DESCRIPTION
The documents folder should not be used for caching. I changed the folder to `.cachesDirectory` by default. Using this folder we don't need `isExcludedFromBackupKey` at all.

Fixes https://github.com/3lvis/Networking/issues/237