### PR TITLE
Added row body to response so it can be used in cases when json parsing fail or posibly in other circumstances.

### DIFF
--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -28,6 +28,7 @@ public class FailureResponse: Response {
 
 public class JSONResponse: Response {
     let json: JSON
+    public let body: Any?
 
     public var dictionaryBody: [String: Any] {
         return json.dictionary
@@ -48,9 +49,9 @@ public class JSONResponse: Response {
         }
     }
 
-    init(json: JSON, response: HTTPURLResponse) {
+    init(json: JSON, response: HTTPURLResponse, body: Any? = nil) {
         self.json = json
-
+        self.body = body
         super.init(response: response)
     }
 }

--- a/Sources/Result.swift
+++ b/Sources/Result.swift
@@ -49,7 +49,7 @@ public enum JSONResult: Result {
         if let finalError = returnedError {
             self = .failure(FailureJSONResponse(json: json, response: response, error: finalError))
         } else {
-            self = .success(SuccessJSONResponse(json: json, response: response))
+            self = .success(SuccessJSONResponse(json: json, response: response, body: body))
         }
     }
 }


### PR DESCRIPTION
Fixes #255

I would suggest instead fix json parsing so it is better suited of parsing of data returned from server as I pointed out in this bug report but I get over this problem by being able to access row body and parse it by myself.