### PR TITLE
Set swift-tools-version to 4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 
 // Licensed under the **MIT** license
 // Copyright (c) 2016 Elvis Nuñez


### PR DESCRIPTION
Since the current `swift-tools-version` in `Package.swift` is set to `4.0` it seems to create a problem when using `self.jpegData(compressionQuality: 1)` which was introduced in swift 4.2. 

This PR sets the `swift-tools-version` in `Package.swift` to 4.2