### PR TITLE
feat: query params on new GET (path merge) + DELETE

### DIFF
--- a/Sources/Networking/Networking+HTTPRequests.swift
+++ b/Sources/Networking/Networking+HTTPRequests.swift
@@ -96,6 +96,10 @@ public extension Networking {
             return .failure(error)
         }
     }
+
+    func delete<T: Decodable>(_ path: String, parameters: [String: Any]) async -> Result<T, NetworkingError> {
+        return await handle(.delete, path: path, parameters: parameters)
+    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/Networking/Networking+New.swift
+++ b/Sources/Networking/Networking+New.swift
@@ -30,21 +30,35 @@ extension Networking {
     }
 
     private func createRequest(path: String, requestType: RequestType, parameters: Any?) throws -> URLRequest {
-        guard var urlComponents = URLComponents(string: try composedURL(with: path).absoluteString) else {
+        // Split a query embedded in the path so it survives URL building instead of being
+        // percent-encoded into the path (encodeUTF8 uses .urlPathAllowed, which escapes "?").
+        let pathParts = path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
+        let rawPath = String(pathParts[0])
+        let pathQuery = pathParts.count > 1 ? String(pathParts[1]) : nil
+
+        guard var urlComponents = URLComponents(string: try composedURL(with: rawPath).absoluteString) else {
             throw URLError(.badURL)
         }
 
-        if requestType == .get, let queryParameters = parameters as? [String: Any] {
-            urlComponents.queryItems = queryParameters.map { key, value in
-                URLQueryItem(name: key, value: "\(value)")
-            }
+        // GET and DELETE carry parameters in the query string; merge them onto any query the
+        // path already had rather than replacing it.
+        let carriesQueryParameters = requestType == .get || requestType == .delete
+        var queryItems = [URLQueryItem]()
+        if let pathQuery, let parsed = URLComponents(string: "?\(pathQuery)")?.queryItems {
+            queryItems.append(contentsOf: parsed)
+        }
+        if carriesQueryParameters, let queryParameters = parameters as? [String: Any] {
+            queryItems.append(contentsOf: queryParameters.map { URLQueryItem(name: $0, value: "\($1)") })
+        }
+        if !queryItems.isEmpty {
+            urlComponents.queryItems = queryItems
         }
 
         guard let url = urlComponents.url else {
             throw URLError(.badURL)
         }
 
-        let parameterType: Networking.ParameterType? = (requestType == .get || parameters == nil) ? nil : .json
+        let parameterType: Networking.ParameterType? = (carriesQueryParameters || parameters == nil) ? nil : .json
         var request = URLRequest(
             url: url,
             requestType: requestType,
@@ -58,7 +72,7 @@ extension Networking {
             headerFields: headerFields
         )
 
-        if requestType != .get, let parameters = parameters {
+        if !carriesQueryParameters, let parameters = parameters {
             request.httpBody = try JSONSerialization.data(withJSONObject: parameters, options: [])
         }
 

--- a/Sources/Networking/NetworkingResponse.swift
+++ b/Sources/Networking/NetworkingResponse.swift
@@ -15,7 +15,9 @@ public struct AnyCodable: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
-        if let value = try? container.decode(Bool.self) {
+        if container.decodeNil() {
+            self.value = NSNull()
+        } else if let value = try? container.decode(Bool.self) {
             self.value = value
         } else if let value = try? container.decode(Int.self) {
             self.value = value
@@ -35,7 +37,9 @@ public struct AnyCodable: Decodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
 
-        if let value = self.value as? Bool {
+        if self.value is NSNull {
+            try container.encodeNil()
+        } else if let value = self.value as? Bool {
             try container.encode(value)
         } else if let value = self.value as? Int {
             try container.encode(value)

--- a/Tests/NetworkingTests/DELETEIntegrationTests.swift
+++ b/Tests/NetworkingTests/DELETEIntegrationTests.swift
@@ -49,6 +49,17 @@ class DELETEIntegrationTests: XCTestCase {
         }
     }
 
+    func testDELETEWithURLEncodedParameters() async throws {
+        let networking = Networking(baseURL: baseURL)
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.delete("/delete", parameters: ["userId": 25])
+        switch result {
+        case let .success(response):
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/delete?userId=25")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
+        }
+    }
+
     // Disabling because I haven't found a way to test cancel
     /*
     func testCancelDELETEWithPath() {

--- a/Tests/NetworkingTests/GETIntegrationTests.swift
+++ b/Tests/NetworkingTests/GETIntegrationTests.swift
@@ -110,6 +110,17 @@ class GETIntegrationTests: XCTestCase {
         }
     }
 
+    func testGETWithURLEncodedParametersWithExistingQuery() async throws {
+        let networking = Networking(baseURL: baseURL)
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get?accountId=123", parameters: ["userId": 5])
+        switch result {
+        case let .success(response):
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get?accountId=123&userId=5")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
+        }
+    }
+
     func testGETWithURLEncodedParametersWithPercentEncoding() async throws {
         let networking = Networking(baseURL: baseURL)
         let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get", parameters: ["name": "Elvis Nuñez"])

--- a/Tests/NetworkingTests/GETTests.swift
+++ b/Tests/NetworkingTests/GETTests.swift
@@ -10,10 +10,6 @@ struct Friend: Decodable {
 class GETTests: XCTestCase {
     let baseURL = "http://httpbin.org"
 
-    // I'm not sure how it implement this, since I need a service that returns a faulty status code, meaning not 2XX, and at the same time it returns a JSON response.
-    func testGETWithInvalidPathAndJSONError() {
-    }
-
     // Disabling since I don't know a reliable way to test cancellations in async/await
     /*
     func testCancelGETWithPath() async throws {

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -1,0 +1,18 @@
+# API modernization plan
+
+Tracking the move from the legacy callback/`old*` API to the async/await typed API,
+and the test work that depends on it. CI runs the full suite against a local
+`go-httpbin` (see `.github/workflows/ci.yml`), so integration tests are deterministic.
+
+## Done
+
+- [x] Migrate CI to GitHub Actions + local go-httpbin; remove dead CircleCI/Travis/buddybuild config & webhooks.
+- [x] Split offline vs `*IntegrationTests`; revive multipart image-upload test.
+- [x] Revive GET query-parameter tests on the new `get(_:parameters:)` API (incl. percent-encoding).
+- [x] Fix new-API query handling: a query embedded in the path (e.g. `get("/x?a=1", parameters:)`) is now merged instead of being percent-encoded into the path (was a 404).
+- [x] Add `delete(_:parameters:)` to the new API (DELETE params routed to the query, matching GET) + test.
+
+## Open items
+
+- [ ] **Revive the cancellation test suite on the new API.** Eight tests are currently commented out (`testCancel{GET,POST,PUT,PATCH,DELETE}WithPath`, `testCancelImageDownload`, `testCancelAllRequests`, `testCancelRequestsReturnInMainThread`). They were disabled because cancellation wasn't reliably testable. go-httpbin's `/delay/{n}` endpoint makes it deterministic now: fire a request at `/delay/5`, cancel via `Task.cancel()` / `cancelAllRequests()`, assert the result is a cancellation error. Rewrite to async/await; verify the library actually surfaces `URLError.cancelled` (this may expose unfinished cancel behavior). Use the new endpoints, not `old*`.
+- [ ] **Remove the legacy `old*` API and migrate every remaining test to the new API.** Delete `oldGet`/`oldPost`/`oldPut`/`oldPatch`/`oldDelete` and `cancelOld*`; port the `*IntegrationTests` that still use them (GET/POST/PUT/PATCH/DELETE, Download, Networking, Response, Unauthorized) onto `get`/`post`/`put`/`patch`/`delete` + `NetworkingResponse`. This is the larger follow-up the query-param and DELETE work above feeds into.


### PR DESCRIPTION
## What

Adds query-parameter support to the new async API and fixes a decoding gap, with revived tests. Stacked on #284 (base: `ci/github-actions`).

## Changes

1. **GET — query embedded in the path now merges** instead of breaking. `get("/x?a=1", parameters: ["b": 2])` previously 404'd because `encodeUTF8()` (`.urlPathAllowed`) percent-encoded the `?` into the path. `createRequest` now splits the path's query, parses it, and merges it with the parameters.
2. **DELETE query parameters** — added `delete(_:parameters:)`, routing DELETE params to the query string (like GET), restoring parity with the removed `oldDelete(_:parameters:)`.
3. **`AnyCodable` handles JSON `null`** — it previously threw on any `null` value, so `NetworkingResponse` failed to decode any response with a null field (e.g. httpbin `/delete` returns `"json": null`). Now decodes/encodes null as `NSNull`.

## Tests (all against local go-httpbin)

- Revived `testGETWithURLEncodedParametersWithExistingQuery` (merge) and `testDELETEWithURLEncodedParameters` on the **new** API.
- Removed the redundant empty `testGETWithInvalidPathAndJSONError` stub — non-2XX + JSON-error-body is already covered by `testErrorNetworkingJSON`.
- Full suite: **134 tests, 0 failures**.

## Follow-ups (see `docs/api-modernization.md`)

- Revive the 8 cancellation tests on the new API using go-httpbin `/delay`.
- Remove the legacy `old*` API and migrate every remaining test to the new endpoints.
