### PR TITLE
feat: add response caching + statusCode to the new API

### DIFF
--- a/Sources/Networking/Helpers.swift
+++ b/Sources/Networking/Helpers.swift
@@ -56,7 +56,9 @@ extension FileManager {
 
     public func remove(at url: URL) throws {
         let path = url.path
-        guard FileManager.default.isDeletableFile(atPath: url.path) else { return }
+        // `isDeletableFile` is true for a missing file with a writable parent, so removeItem would
+        // throw "couldn't be removed" on a cache miss. Only attempt removal when the file exists.
+        guard FileManager.default.fileExists(atPath: path) else { return }
 
         try FileManager.default.removeItem(atPath: path)
     }

--- a/Sources/Networking/Networking+HTTPRequests.swift
+++ b/Sources/Networking/Networking+HTTPRequests.swift
@@ -41,8 +41,8 @@ public extension Networking {
         await cancelRequest(.data, requestType: .get, url: url)
     }
 
-    func get<T: Decodable>(_ path: String, parameters: Any? = nil) async -> Result<T, NetworkingError> {
-        return await handle(.get, path: path, parameters: parameters)
+    func get<T: Decodable>(_ path: String, parameters: Any? = nil, cachingLevel: CachingLevel = .none) async -> Result<T, NetworkingError> {
+        return await handle(.get, path: path, parameters: parameters, cachingLevel: cachingLevel)
     }
 
     func post<T: Decodable>(_ path: String, parameters: [String: Any]) async -> Result<T, NetworkingError> {

--- a/Sources/Networking/Networking+New.swift
+++ b/Sources/Networking/Networking+New.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Networking {
-    func handle<T: Decodable>(_ requestType: RequestType, path: String, parameters: Any?) async -> Result<T, NetworkingError> {
+    func handle<T: Decodable>(_ requestType: RequestType, path: String, parameters: Any?, cachingLevel: CachingLevel = .none) async -> Result<T, NetworkingError> {
         do {
             logger.info("Starting \(requestType.rawValue) request to \(path, privacy: .public)")
 
@@ -9,9 +9,20 @@ extension Networking {
                 return try await handleFakeRequest(fakeRequest, path: path, requestType: requestType)
             }
 
+            if cachingLevel != .none,
+                let cachedData = try objectFromCache(for: path, cacheName: nil, cachingLevel: cachingLevel, responseType: .json) as? Data,
+                let url = try? composedURL(with: path) {
+                let cachedResponse = HTTPURLResponse(url: url, statusCode: 200)
+                return try handleSuccessfulResponse(responseData: cachedData, path: path, httpResponse: cachedResponse)
+            }
+
             let request = try createRequest(path: path, requestType: requestType, parameters: parameters)
             let (responseData, response) = try await session.data(for: request)
-            return try handleResponse(responseData: responseData, response: response, path: path)
+            let result: Result<T, NetworkingError> = try handleResponse(responseData: responseData, response: response, path: path)
+            if cachingLevel != .none, case .success = result {
+                try? cacheOrPurgeData(data: responseData, path: path, cacheName: nil, cachingLevel: cachingLevel)
+            }
+            return result
 
         } catch {
             return handleRequestError(error: error)
@@ -115,7 +126,7 @@ extension Networking {
                 (key as? String).map { ($0, AnyCodable(value)) }
             })
             let body = try JSONDecoder().decode([String: AnyCodable].self, from: responseData)
-            let networkingJSON = NetworkingResponse(headers: headers, body: body)
+            let networkingJSON = NetworkingResponse(statusCode: httpResponse.statusCode, headers: headers, body: body)
             return .success(networkingJSON as! T)
         } else {
             let decoder = JSONDecoder()

--- a/Sources/Networking/NetworkingResponse.swift
+++ b/Sources/Networking/NetworkingResponse.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public struct NetworkingResponse: Decodable {
+    public let statusCode: Int
     public let headers: [String: AnyCodable]
     public let body: [String: AnyCodable]
 }

--- a/Tests/NetworkingTests/GETIntegrationTests.swift
+++ b/Tests/NetworkingTests/GETIntegrationTests.swift
@@ -131,4 +131,25 @@ class GETIntegrationTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+
+    // /uuid returns a fresh value per call, so a matching second response proves the first
+    // was served from cache. Also exercises the new statusCode on NetworkingResponse.
+    func testGETResponseCaching() async throws {
+        let cache = NSCache<AnyObject, AnyObject>()
+        let networking = Networking(baseURL: baseURL, cache: cache)
+
+        let first: Result<NetworkingResponse, NetworkingError> = await networking.get("/uuid", cachingLevel: .memory)
+        let second: Result<NetworkingResponse, NetworkingError> = await networking.get("/uuid", cachingLevel: .memory)
+
+        guard case let .success(firstResponse) = first, case let .success(secondResponse) = second else {
+            return XCTFail("expected both requests to succeed")
+        }
+        XCTAssertEqual(firstResponse.statusCode, 200)
+        XCTAssertNotNil(firstResponse.body.string(for: "uuid"))
+        XCTAssertEqual(
+            firstResponse.body.string(for: "uuid"),
+            secondResponse.body.string(for: "uuid"),
+            "the second request should return the cached response"
+        )
+    }
 }

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -13,6 +13,16 @@ and the test work that depends on it. CI runs the full suite against a local
 - [x] Add `delete(_:parameters:)` to the new API (DELETE params routed to the query, matching GET) + test.
 - [x] Revive the cancellation suite on the new API (`CancellationIntegrationTests`): GET/POST/PUT/PATCH/DELETE via `Task.cancel()`, image download (thrown `URLError.cancelled`), and `cancelAllRequests()`, all deterministic via go-httpbin `/delay`. Added a `NetworkingError.cancelled` case so cancellation surfaces cleanly instead of as a generic `.unexpectedError`. Retired `testCancelRequestsReturnInMainThread` — "callback returns on the main thread" is an old-callback concept with no async/await equivalent.
 
+## In progress: remove the legacy `old*` API (branch `feature/remove-old-api`)
+
+Plan (decisions: add caching + statusCode to the new API):
+
+- [ ] Add `statusCode` to `NetworkingResponse` (populate from the HTTP response).
+- [ ] Add `cachingLevel:` to the new `get` and wire response caching into the async `handle()` path.
+- [ ] Migrate all `old*` test call sites (66 across 12 files) to the new `get/post/put/patch/delete` + `NetworkingResponse`, mapping `JSONResult`/`dictionaryBody`/`.error.code` to `Result`/`body`/`NetworkingError`.
+- [ ] Delete `oldGet/oldPost/oldPut/oldPatch/oldDelete`, `cancelOld*`, `cancel(_ requestID:)`, and now-unused private helpers.
+- [ ] Full suite green against go-httpbin throughout.
+
 ## Open items
 
 - [ ] **Remove `cancel(_ requestID:)`** (recommended). History (`git show 3b35350`, 2016): request methods returned a `UUID` that was stamped onto `URLSessionTask.taskDescription`, and `cancel(requestID:)` matched on it — its purpose was cancelling *one* of several concurrent requests to the *same URL*, which path-based cancel can't disambiguate. The async/await migration (#268) removed the ID-returning API and the `taskDescription` writer; a later commit re-added only the matcher, so it's been dead code (nothing sets `taskDescription`). The capability it provided is now covered natively by holding each request's `Task` and calling `.cancel()` — proven by `CancellationIntegrationTests.testCancelOneOfTwoConcurrentRequestsToSameURL`. Re-wiring `taskDescription` would just duplicate what `Task` already gives, so remove the method during the `old*` cleanup.

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -13,15 +13,23 @@ and the test work that depends on it. CI runs the full suite against a local
 - [x] Add `delete(_:parameters:)` to the new API (DELETE params routed to the query, matching GET) + test.
 - [x] Revive the cancellation suite on the new API (`CancellationIntegrationTests`): GET/POST/PUT/PATCH/DELETE via `Task.cancel()`, image download (thrown `URLError.cancelled`), and `cancelAllRequests()`, all deterministic via go-httpbin `/delay`. Added a `NetworkingError.cancelled` case so cancellation surfaces cleanly instead of as a generic `.unexpectedError`. Retired `testCancelRequestsReturnInMainThread` — "callback returns on the main thread" is an old-callback concept with no async/await equivalent.
 
-## In progress: remove the legacy `old*` API (branch `feature/remove-old-api`)
+## Removing the legacy `old*` API
 
-Plan (decisions: add caching + statusCode to the new API):
+Decisions: add caching + statusCode to the new API; migrate per-verb in separate PRs.
 
-- [ ] Add `statusCode` to `NetworkingResponse` (populate from the HTTP response).
-- [ ] Add `cachingLevel:` to the new `get` and wire response caching into the async `handle()` path.
-- [ ] Migrate all `old*` test call sites (66 across 12 files) to the new `get/post/put/patch/delete` + `NetworkingResponse`, mapping `JSONResult`/`dictionaryBody`/`.error.code` to `Result`/`body`/`NetworkingError`.
-- [ ] Delete `oldGet/oldPost/oldPut/oldPatch/oldDelete`, `cancelOld*`, `cancel(_ requestID:)`, and now-unused private helpers.
-- [ ] Full suite green against go-httpbin throughout.
+Foundation (this PR):
+
+- [x] Add `statusCode` to `NetworkingResponse` (populated from the HTTP response).
+- [x] Add `cachingLevel:` to the new `get` and wire response caching into the async `handle()` path (+ real cache-hit test; fixed a latent `remove(at:)` cache-miss bug).
+
+Then, one verb per PR — migrate the `old*` test call sites to the new API and delete that verb's `old*`/`cancelOld*`:
+
+- [ ] `oldGet` → `get` (incl. the 3 GET cache tests).
+- [ ] `oldPost` → `post`.
+- [ ] `oldPut` → `put`.
+- [ ] `oldPatch` → `patch`.
+- [ ] `oldDelete` → `delete`.
+- [ ] Remove `cancel(_ requestID:)` and any now-unused private helpers (`handleJSONRequest`, `JSONResult`, `cacheOrPurgeJSON`…), keeping what downloads use.
 
 ## Open items
 


### PR DESCRIPTION
## What

Adds two capabilities to the new async API as the **foundation for removing the legacy `old*` API** (which will follow, one verb per PR). No `old*` removed yet — this PR only adds; nothing existing changes behavior.

## Changes

1. **`NetworkingResponse.statusCode`** — the new API previously exposed only `headers`/`body`; `JSONResult` (old API) exposed the status code. Added `statusCode`, populated from the HTTP response, so success-path status assertions survive migration.
2. **Response caching on `get`** — `get(_:parameters:cachingLevel:)` now caches responses in the async `handle()` path, using the existing `objectFromCache` / `cacheOrPurgeData` (Data-based, consistent read/write). The old `oldGet(cachingLevel:)` had caching; the new `get` didn't.
3. **Bug fix in `Helpers.remove(at:)`** — it guarded on `isDeletableFile`, which is `true` for a *missing* file with a writable parent, so `removeItem` threw "couldn't be removed" on a cache miss. Now guards on `fileExists`. (Latent bug the old fake-based cache tests never hit, since fakes bypass caching.)

## Tests

- `testGETResponseCaching` (new): two `get("/uuid", cachingLevel: .memory)` calls — `/uuid` returns a fresh value per request, so a matching second response proves it was served from cache. Also asserts `statusCode == 200`.
- Full suite against local go-httpbin: **143 tests, 0 failures**.

## Follow-ups (see `docs/api-modernization.md`)

One verb per PR: migrate `oldGet`→`get` (incl. the 3 GET cache tests), then `oldPost`/`oldPut`/`oldPatch`/`oldDelete`, then remove `cancel(_ requestID:)` + now-unused helpers.
