### PR TITLE
refactor: migrate oldGet to the new get API

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To authenticate using [basic authentication](http://www.w3.org/Protocols/HTTP/1.
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
 networking.setAuthorizationHeader(username: "aladdin", password: "opensesame")
-let result = try await networking.oldGet("/basic-auth/aladdin/opensesame")
+let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/basic-auth/aladdin/opensesame")
 // Successfully authenticated!
 ```
 
@@ -86,7 +86,7 @@ To authenticate using a [bearer token](https://tools.ietf.org/html/rfc6750) **"A
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
 networking.setAuthorizationHeader(token: "AAAFFAAAA3DAAAAAA")
-let result = try await networking.oldGet("/get")
+let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get")
 // Successfully authenticated!
 ```
 
@@ -97,7 +97,7 @@ To authenticate using a custom authentication header, for example **"Token token
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
 networking.setAuthorizationHeader(headerValue: "Token token=AAAFFAAAA3DAAAAAA")
-let result = try await networking.oldGet("/get")
+let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get")
 // Successfully authenticated!
 ```
 
@@ -106,7 +106,7 @@ Providing the following authentication header `Anonymous-Token: AAAFFAAAA3DAAAAA
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
 networking.setAuthorizationHeader(headerKey: "Anonymous-Token", headerValue: "AAAFFAAAA3DAAAAAA")
-let result = try await networking.oldGet("/get")
+let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get")
 // Successfully authenticated!
 ```
 
@@ -120,12 +120,12 @@ Making a request is as simple as just calling `get`, `post`, `put`, or `delete`.
 
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-let result = try await networking.oldGet("/get")
+let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get")
 switch result {
 case .success(let response):
-    let json = response.dictionaryBody
-    // Do something with JSON, you can also get arrayBody
-case .failure(let response):
+    let body = response.body // [String: AnyCodable]
+    let statusCode = response.statusCode
+case .failure(let error):
     // Handle error
 }
 ```
@@ -154,51 +154,42 @@ let result = try await networking.oldPost("/post", parameters: ["username" : "ja
  */
 ```
 
-You can get the response headers inside the success.
+You can get the response headers and status code inside the success.
 
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-let result = try await networking.oldGet("/get")
+let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get")
 switch result {
 case .success(let response):
-    let headers = response.allHeaderFields
-    // Do something with headers
-case .failure(let response):
+    let headers = response.headers // [String: AnyCodable]
+    let statusCode = response.statusCode // Int
+case .failure(let error):
     // Handle error
 }
 ```
 
-### The NetworkingResult type
+### The Result type
 
-The [NetworkingResult](https://github.com/3lvis/Networking/blob/master/Sources/NetworkingResult.swift) type is an enum that has two cases: `success` and `failure`. The `success` case has a response, the `failure` case has an error and a response, none of these ones are optionals.
+`get` returns Swift's [Result](https://developer.apple.com/documentation/swift/result) with two cases: `.success(let response)` and `.failure(let error)`. The success carries the decoded value, the failure a `NetworkingError`.
 
-Here's how to use it:
+`get` is generic over any `Decodable`, so you can decode straight into your own model — no manual JSON digging:
 
 ```swift
-// The best way
+struct Recipe: Decodable { let title: String }
+
 let networking = Networking(baseURL: "http://fakerecipes.com")
-let result = try await networking.oldGet("/recipes")
+let result: Result<[Recipe], NetworkingError> = await networking.get("/recipes")
 switch result {
-case .success(let response):
-    // We know we'll be receiving an array with the best recipes, so we can just do:
-    let recipes = response.arrayBody // BOOM, no optionals. [[String: Any]]
-
-    // If we need headers or response status code we can use the HTTPURLResponse for this.
-    let headers = response.headers // [String: Any]
-case .failure(let response):
-    // Non-optional error ✨
-    let errorCode = response.error.code
-
-    // Our backend developer told us that they will send a json with some
-    // additional information on why the request failed, this will be a dictionary.
-    let json = response.dictionaryBody // BOOM, no optionals here [String: Any]
-
-    // We want to know the headers of the failed response.
-    let headers = response.headers // [String: Any]
+case .success(let recipes):
+    // recipes is [Recipe] — fully typed, no optionals
+    print(recipes.map(\.title))
+case .failure(let error):
+    // error is a NetworkingError carrying the status code and message
+    print(error.localizedDescription)
 }
 ```
 
-And that's how we do things in **Networking** without optionals.
+Use `NetworkingResponse` as the type when you want the raw `statusCode`, `headers`, and `body` instead of a model.
 
 ## Choosing a Content or Parameter Type
 
@@ -266,17 +257,17 @@ let result = try await networking.oldPost("/upload", parameterType: .Custom("app
 
 ## Cancelling a request
 
-### Using path
-
-Cancelling any request for a specific path is really simple. Beware that cancelling a request will cause the request to return with an error with status code URLError.cancelled.
+Hold the `Task` running the request and call `cancel()` on it. A cancelled request fails with `NetworkingError.cancelled`.
 
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-let result = try await networking.oldGet("/get")
-// Cancelling a GET request returns an error with code URLError.cancelled which means cancelled request
+let task = Task {
+    let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get")
+    // On cancellation this is .failure(.cancelled)
+}
 
 // In another place
-networking.cancelGET("/get")
+task.cancel()
 ```
 
 ## Faking a request
@@ -286,10 +277,12 @@ Faking a request means that after calling this method on a specific path, any ca
 **Faking with successfull response**:
 
 ```swift
+struct Story: Decodable { let id: Int; let title: String }
+
 let networking = Networking(baseURL: "https://api-news.layervault.com/api/v2")
 networking.fakeGET("/stories", response: [["id" : 47333, "title" : "Site Design: Aquest"]])
-let result = try await networking.oldGet("/stories")
-// JSON containing stories
+let result: Result<[Story], NetworkingError> = await networking.get("/stories")
+// .success carrying the stories
 ```
 
 **Faking with contents of a file**:
@@ -299,8 +292,8 @@ If your file is not located in the main bundle you have to specify using the bun
 ```swift
 let networking = Networking(baseURL: baseURL)
 networking.fakeGET("/entries", fileName: "entries.json")
-let result = try await networking.oldGet("/entries")
-// JSON with the contents of entries.json
+let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/entries")
+// Response with the contents of entries.json
 ```
 
 **Faking with status code**:
@@ -310,8 +303,8 @@ If you do not provide a status code for this fake request, the default returned 
 ```swift
 let networking = Networking(baseURL: "https://api-news.layervault.com/api/v2")
 networking.fakeGET("/stories", response: nil, statusCode: 500)
-let result = try await networking.oldGet("/stories")
-// error with status code 500
+let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/stories")
+// .failure with status code 500
 ```
 
 ## Downloading and caching an image

--- a/Sources/Networking/Networking+HTTPRequests.swift
+++ b/Sources/Networking/Networking+HTTPRequests.swift
@@ -2,17 +2,6 @@ import Foundation
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public extension Networking {
-    /// GET request to the specified path.
-    ///
-    /// - Parameters:
-    ///   - path: The path for the GET request.
-    ///   - parameters: The parameters to be used, they will be serialized using Percent-encoding and appended to the URL.
-    func oldGet(_ path: String, parameters: Any? = nil, cachingLevel: CachingLevel = .none) async throws -> JSONResult {
-        let parameterType: ParameterType = parameters != nil ? .formURLEncoded : .none
-
-        return try await handleJSONRequest(.get, path: path, cacheName: nil, parameterType: parameterType, parameters: parameters, responseType: .json, cachingLevel: cachingLevel)
-    }
-
     /// Registers a fake GET request for the specified path. After registering this, every GET request to the path, will return the registered response.
     ///
     /// - Parameters:
@@ -31,14 +20,6 @@ public extension Networking {
     ///   - bundle: The Bundle where the file is located.
     func fakeGET(_ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0) {
         registerFake(requestType: .get, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
-    }
-
-    /// Cancels the GET request for the specified path. This causes the request to complete with error code URLError.cancelled.
-    ///
-    /// - Parameter path: The path for the cancelled GET request
-    func cancelOldGET(_ path: String) async throws {
-        let url = try composedURL(with: path)
-        await cancelRequest(.data, requestType: .get, url: url)
     }
 
     func get<T: Decodable>(_ path: String, parameters: Any? = nil, cachingLevel: CachingLevel = .none) async -> Result<T, NetworkingError> {

--- a/Tests/NetworkingTests/FakeRequestTests.swift
+++ b/Tests/NetworkingTests/FakeRequestTests.swift
@@ -165,14 +165,12 @@ extension FakeRequestTests {
 
         networking.fakeGET("/stories", response: ["name": "Elvis"])
 
-        let result = try await networking.oldGet("/stories")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/stories")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let value = json["name"] as? String
-            XCTAssertEqual(value, "Elvis")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "name"), "Elvis")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -183,17 +181,16 @@ extension FakeRequestTests {
         let startTime1 = Date()
         networking.fakeGET("/stories", response: ["name": "Elvis"], delay: delay)
 
-        let firstResult = try await networking.oldGet("/stories")
+        let firstResult: Result<NetworkingResponse, NetworkingError> = await networking.get("/stories")
         let endTime1 = Date()
         let elapsedTime1 = endTime1.timeIntervalSince(startTime1)
         XCTAssertGreaterThanOrEqual(elapsedTime1, delay, "The delay was not correctly applied")
 
         switch firstResult {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["name"] as? String, "Elvis")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "name"), "Elvis")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -202,29 +199,33 @@ extension FakeRequestTests {
 
         networking.fakeGET("/stories", response: nil, statusCode: 401)
 
-        let result = try await networking.oldGet("/stories")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/stories")
         switch result {
         case .success:
             XCTFail()
-        case let .failure(response):
-            XCTAssertEqual(response.error.code, 401)
+        case let .failure(error):
+            guard case let .clientError(statusCode, _) = error else {
+                return XCTFail("expected a client error, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 401)
         }
     }
 
     func testFakeGETWithInvalidPathAndJSONError() async throws {
         let networking = Networking(baseURL: baseURL)
 
-        let expectedResponse = ["error_message": "Shit went down"]
-        networking.fakeGET("/stories", response: expectedResponse, statusCode: 401)
+        networking.fakeGET("/stories", response: ["error": "Shit went down"], statusCode: 401)
 
-        let result = try await networking.oldGet("/stories")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/stories")
         switch result {
         case .success:
             XCTFail()
-        case let .failure(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json as! [String: String], expectedResponse)
-            XCTAssertEqual(response.error.code, 401)
+        case let .failure(error):
+            guard case let .clientError(statusCode, message) = error else {
+                return XCTFail("expected a client error, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 401)
+            XCTAssertTrue(message.contains("Shit went down"))
         }
     }
 
@@ -233,15 +234,12 @@ extension FakeRequestTests {
 
         networking.fakeGET("/entries", fileName: "entries.json", bundle: .module)
 
-        let result = try await networking.oldGet("/entries")
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.get("/entries")
         switch result {
-        case let .success(response):
-            let json = response.arrayBody
-            let entry = json[0]
-            let value = entry["title"] as? String
-            XCTAssertEqual(value, "Entry 1")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .success(entries):
+            XCTAssertEqual(entries.first?.string(for: "title"), "Entry 1")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -259,39 +257,34 @@ extension FakeRequestTests {
         networking.fakeGET("/users/melos", response: json, statusCode: 200)
         networking.fakeGET("/users/{userID}", response: json, statusCode: 200)
 
-        let result = try await networking.oldGet("/users/10")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/users/10")
         switch result {
-        case .success(let response):
-            let json = response.dictionaryBody
-            let name = json["name"] as? String
-            XCTAssertEqual(name, "Name 10")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .success(response):
+            XCTAssertEqual(response.body.string(for: "name"), "Name 10")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
 
-        let result2 = try await networking.oldGet("/users/20")
+        let result2: Result<NetworkingResponse, NetworkingError> = await networking.get("/users/20")
         switch result2 {
-        case .success(let response):
-            let json = response.dictionaryBody
-            let name = json["name"] as? String
-            XCTAssertEqual(name, "Name 20")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .success(response):
+            XCTAssertEqual(response.body.string(for: "name"), "Name 20")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testFakeGETUsingHeader() async throws {
         let networking = Networking(baseURL: baseURL)
 
-        networking.fakeGET("/story", response: nil, headerFields: ["uid": "12345678"])
+        networking.fakeGET("/story", response: ["ok": true], headerFields: ["uid": "12345678"])
 
-        let result = try await networking.oldGet("/story")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/story")
         switch result {
         case let .success(response):
-            let headers = response.headers
-            XCTAssertEqual(headers["uid"] as! String, "12345678")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 }

--- a/Tests/NetworkingTests/GETIntegrationTests.swift
+++ b/Tests/NetworkingTests/GETIntegrationTests.swift
@@ -7,96 +7,74 @@ class GETIntegrationTests: XCTestCase {
 
     func testGET() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldGet("/get")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-
-            guard let url = json["url"] as? String else { XCTFail(); return }
-            XCTAssertEqual(url, "\(TestConfig.httpbinBaseURL)/get")
-
-            let headers = httpbinEchoedMap(json, "headers")
-            let contentType = headers["Content-Type"]
-            XCTAssertNil(contentType)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get")
+            XCTAssertNil(httpbinEchoedMap(response, "headers")["Content-Type"])
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testGETWithFullPath() async throws {
         let networking = Networking()
-        let result = try await networking.oldGet("\(TestConfig.httpbinBaseURL)/get")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("\(TestConfig.httpbinBaseURL)/get")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-
-            guard let url = json["url"] as? String else { XCTFail(); return }
-            XCTAssertEqual(url, "\(TestConfig.httpbinBaseURL)/get")
-
-            let headers = httpbinEchoedMap(json, "headers")
-            let contentType = headers["Content-Type"]
-            XCTAssertNil(contentType)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get")
+            XCTAssertNil(httpbinEchoedMap(response, "headers")["Content-Type"])
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testGETWithHeaders() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldGet("/get")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/get")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            guard let url = json["url"] as? String else { XCTFail(); return }
-            XCTAssertEqual(url, "\(TestConfig.httpbinBaseURL)/get")
-
-            let headers = response.headers
-            XCTAssertTrue((headers["Content-Type"] as? String)?.hasPrefix("application/json") ?? false)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get")
+            XCTAssertTrue(response.headers.string(for: "Content-Type")?.hasPrefix("application/json") ?? false)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testGETWithInvalidPath() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldGet("/invalidpath")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/invalidpath")
         switch result {
         case .success:
             XCTFail()
-        case let .failure(response):
-            XCTAssertEqual(response.error.code, 404)
+        case let .failure(error):
+            guard case let .clientError(statusCode, _) = error else {
+                return XCTFail("expected a client error, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 404)
         }
     }
 
     func testStatusCodes() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result200 = try await networking.oldGet("/status/200")
-        switch result200 {
-        case let .success(response):
-            XCTAssertEqual(response.statusCode, 200)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
-        }
 
-        var statusCode = 300
-        let result300 = try await networking.oldGet("/status/\(statusCode)")
-        switch result300 {
-        case .success:
-            XCTFail()
-        case let .failure(response):
-            let connectionError = NSError(domain: Networking.domain, code: statusCode, userInfo: [NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: statusCode)])
-            XCTAssertEqual(response.error, connectionError)
-        }
+        // 2xx succeeds (empty body, so decode as Data).
+        let ok: Result<Data, NetworkingError> = await networking.get("/status/200")
+        if case let .failure(error) = ok { XCTFail("200 should succeed, got \(error)") }
 
-        statusCode = 400
-        let result400 = try await networking.oldGet("/status/\(statusCode)")
-        switch result400 {
-        case .success:
-            XCTFail()
-        case let .failure(response):
-            let connectionError = NSError(domain: Networking.domain, code: statusCode, userInfo: [NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: statusCode)])
-            XCTAssertEqual(response.error, connectionError)
+        // 4xx -> clientError carrying the status code.
+        let clientError: Result<Data, NetworkingError> = await networking.get("/status/404")
+        guard case let .failure(.clientError(clientStatus, _)) = clientError else {
+            return XCTFail("expected a client error")
         }
+        XCTAssertEqual(clientStatus, 404)
+
+        // 5xx -> serverError carrying the status code.
+        let serverError: Result<Data, NetworkingError> = await networking.get("/status/500")
+        guard case let .failure(.serverError(serverStatus, _, _)) = serverError else {
+            return XCTFail("expected a server error")
+        }
+        XCTAssertEqual(serverStatus, 500)
     }
 
     func testGETWithURLEncodedParameters() async throws {

--- a/Tests/NetworkingTests/GETTests.swift
+++ b/Tests/NetworkingTests/GETTests.swift
@@ -14,24 +14,22 @@ class GETTests: XCTestCase {
         let cache = NSCache<AnyObject, AnyObject>()
         let networking = Networking(baseURL: baseURL, configuration: .default, cache: cache)
         networking.fakeGET("/get", response: ["key": "value1"])
-        let firstResult = try await networking.oldGet("/get", cachingLevel: .memory)
+        let firstResult: Result<NetworkingResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memory)
         switch firstResult {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["key"] as? String, "value1")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "key"), "value1")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
 
         networking.fakeGET("/get", response: ["key": "value2"])
 
-        let secondResult = try await networking.oldGet("/get", cachingLevel: .memory)
+        let secondResult: Result<NetworkingResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memory)
         switch secondResult {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["key"] as? String, "value2")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "key"), "value2")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -39,23 +37,21 @@ class GETTests: XCTestCase {
         let cache = NSCache<AnyObject, AnyObject>()
         let networking = Networking(baseURL: baseURL, configuration: .default, cache: cache)
         networking.fakeGET("/get", response: ["key": "value1"])
-        let firstResult = try await networking.oldGet("/get", cachingLevel: .memoryAndFile)
+        let firstResult: Result<NetworkingResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memoryAndFile)
         switch firstResult {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["key"] as? String, "value1")
-        case .failure(let response):
-            XCTFail("Error: \(response.error)")
+            XCTAssertEqual(response.body.string(for: "key"), "value1")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
 
         networking.fakeGET("/get", response: ["key": "value2"])
-        let secondResult = try await networking.oldGet("/get", cachingLevel: .memoryAndFile)
+        let secondResult: Result<NetworkingResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memoryAndFile)
         switch secondResult {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["key"] as? String, "value2")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "key"), "value2")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -63,23 +59,21 @@ class GETTests: XCTestCase {
         let cache = NSCache<AnyObject, AnyObject>()
         let networking = Networking(baseURL: baseURL, configuration: .default, cache: cache)
         networking.fakeGET("/get", response: ["key": "value1"])
-        let firstResult = try await networking.oldGet("/get", cachingLevel: .none)
+        let firstResult: Result<NetworkingResponse, NetworkingError> = await networking.get("/get", cachingLevel: .none)
         switch firstResult {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["key"] as? String, "value1")
-        case .failure(let response):
-            XCTFail("Error: \(response.error)")
+            XCTAssertEqual(response.body.string(for: "key"), "value1")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
 
         networking.fakeGET("/get", response: ["key": "value2"])
-        let secondResult = try await networking.oldGet("/get", cachingLevel: .none)
+        let secondResult: Result<NetworkingResponse, NetworkingError> = await networking.get("/get", cachingLevel: .none)
         switch secondResult {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["key"] as? String, "value2")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "key"), "value2")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 }

--- a/Tests/NetworkingTests/NetworkingIntegrationTests.swift
+++ b/Tests/NetworkingTests/NetworkingIntegrationTests.swift
@@ -8,16 +8,13 @@ class NetworkingIntegrationTests: XCTestCase {
     func testSetAuthorizationHeaderWithUsernameAndPassword() async throws {
         let networking = Networking(baseURL: baseURL)
         networking.setAuthorizationHeader(username: "user", password: "passwd")
-        let result = try await networking.oldGet("/basic-auth/user/passwd")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/basic-auth/user/passwd")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let user = json["user"] as? String
-            let authenticated = json["authenticated"] as? Bool
-            XCTAssertEqual(user, "user")
-            XCTAssertEqual(authenticated, true)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "user"), "user")
+            XCTAssertEqual(response.body.bool(for: "authenticated"), true)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 

--- a/Tests/NetworkingTests/ResponseIntegrationTests.swift
+++ b/Tests/NetworkingTests/ResponseIntegrationTests.swift
@@ -4,16 +4,16 @@ import XCTest
 class ResponseIntegrationTests: XCTestCase {
     let baseURL = TestConfig.httpbinBaseURL
 
-    func testDataAccessor() async throws {
+    func testReflectsRequestHeaderInBody() async throws {
         let networking = Networking(baseURL: baseURL)
-        let expectedBody = ["user-agent": "hi mom!"]
-        networking.headerFields = expectedBody
-        let result = try await networking.oldGet("/user-agent")
+        let expectedUserAgent = "hi mom!"
+        networking.headerFields = ["user-agent": expectedUserAgent]
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.get("/user-agent")
         switch result {
         case let .success(response):
-            XCTAssertEqual(try response.data.toStringStringDictionary().debugDescription, expectedBody.debugDescription)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "user-agent"), expectedUserAgent)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 }

--- a/Tests/NetworkingTests/TestHelpers.swift
+++ b/Tests/NetworkingTests/TestHelpers.swift
@@ -23,6 +23,20 @@ func httpbinEchoedMap(_ json: [String: Any], _ key: String) -> [String: String] 
     return result
 }
 
+/// Same normalization for the new API's `NetworkingResponse`, whose body holds `AnyCodable` values.
+func httpbinEchoedMap(_ response: NetworkingResponse, _ key: String) -> [String: String] {
+    guard let raw = response.body[key]?.value as? [String: AnyCodable] else { return [:] }
+    var result: [String: String] = [:]
+    for (mapKey, value) in raw {
+        if let string = value.value as? String {
+            result[mapKey] = string
+        } else if let array = value.value as? [AnyCodable], let first = array.first?.value as? String {
+            result[mapKey] = first
+        }
+    }
+    return result
+}
+
 struct Helper {
 
     static func removeFileIfNeeded(_ networking: Networking, path: String, cacheName: String? = nil) throws {

--- a/Tests/NetworkingTests/UnauthorizedCallbackIntegrationTests.swift
+++ b/Tests/NetworkingTests/UnauthorizedCallbackIntegrationTests.swift
@@ -13,7 +13,7 @@ class UnauthorizedCallbackIntegrationTests: XCTestCase {
             callbackExecuted = true
         }
 
-        let _ = try await networking.oldGet("/basic-auth/user/passwd")
+        let _: Result<NetworkingResponse, NetworkingError> = await networking.get("/basic-auth/user/passwd")
         XCTAssertTrue(callbackExecuted)
     }
 }

--- a/Tests/NetworkingTests/UnauthorizedCallbackTests.swift
+++ b/Tests/NetworkingTests/UnauthorizedCallbackTests.swift
@@ -14,7 +14,7 @@ class UnauthorizedCallbackTests: XCTestCase {
         }
 
         networking.fakeGET("/hi-mom", response: nil, statusCode: 401)
-        let _ = try await networking.oldGet("/hi-mom")
+        let _: Result<NetworkingResponse, NetworkingError> = await networking.get("/hi-mom")
         XCTAssertTrue(callbackExecuted)
     }
 }

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -4,6 +4,12 @@ Tracking the move from the legacy callback/`old*` API to the async/await typed A
 and the test work that depends on it. CI runs the full suite against a local
 `go-httpbin` (see `.github/workflows/ci.yml`), so integration tests are deterministic.
 
+**Keep the README in sync.** Any change to the public API (a migrated verb, a
+renamed method, a changed return type) must update `README.md` in the same PR —
+its code samples are the docs users copy, so a stale example is a broken one. Each
+per-verb migration below includes swapping that verb's `old*` README examples to
+the new API.
+
 ## Done
 
 - [x] Migrate CI to GitHub Actions + local go-httpbin; remove dead CircleCI/Travis/buddybuild config & webhooks.
@@ -24,7 +30,7 @@ Foundation (this PR):
 
 Then, one verb per PR — migrate the `old*` test call sites to the new API and delete that verb's `old*`/`cancelOld*`:
 
-- [x] `oldGet` → `get` (incl. the 3 GET cache tests); removed `oldGet`/`cancelOldGET`.
+- [x] `oldGet` → `get` (incl. the 3 GET cache tests); removed `oldGet`/`cancelOldGET`; updated README GET/auth/cancellation/faking examples.
 - [ ] `oldPost` → `post`.
 - [ ] `oldPut` → `put`.
 - [ ] `oldPatch` → `patch`.

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -24,7 +24,7 @@ Foundation (this PR):
 
 Then, one verb per PR — migrate the `old*` test call sites to the new API and delete that verb's `old*`/`cancelOld*`:
 
-- [ ] `oldGet` → `get` (incl. the 3 GET cache tests).
+- [x] `oldGet` → `get` (incl. the 3 GET cache tests); removed `oldGet`/`cancelOldGET`.
 - [ ] `oldPost` → `post`.
 - [ ] `oldPut` → `put`.
 - [ ] `oldPatch` → `patch`.


### PR DESCRIPTION
## What

First of the per-verb `old*` removals: migrate every `oldGet` call site to the new `get` API and delete `oldGet` + `cancelOldGET`. Builds on the caching + statusCode foundation (#287).

## Changes

- **Migrated 25 `oldGet` sites across 7 test files** to `get(_:parameters:cachingLevel:) -> Result<…, NetworkingError>`:
  - JSON-object responses → `get<NetworkingResponse>` + `body.string(for:)` / `headers.string(for:)`.
  - Array response (`testFakeGETUsingFile`) → `get<[[String: AnyCodable]]>`.
  - Status-code / empty-body cases (`testStatusCodes`) → `get<Data>` + the `NetworkingError` model (`.clientError(statusCode:)` / `.serverError(statusCode:)`), replacing old `NSError.code` assertions.
  - The 3 GET cache tests → `get(cachingLevel:)`.
- **Removed `oldGet` and `cancelOldGET`** from the public API.
- Added a `NetworkingResponse`-based `httpbinEchoedMap` test helper.
- **Updated the README** GET/auth/cancellation/faking examples to the new `get` API.

## Migration notes (where the new model differs)

- `JSONResult.statusCode` (success) → `NetworkingResponse.statusCode`.
- `JSONResult.error.code` → `NetworkingError.clientError/serverError(statusCode:)`.
- Error bodies surface via `error`/`message`/`errors` keys, so `testFakeGETWithInvalidPathAndJSONError` uses a recognized key and asserts the message.
- A header-only fake (`testFakeGETUsingHeader`) now returns a minimal body, since `NetworkingResponse` requires a decodable body.

## Verification

Full suite against local go-httpbin: **143 tests, 0 failures**.

## Next (see `docs/api-modernization.md`)

`oldPost` → `post`, then `oldPut`/`oldPatch`/`oldDelete`, then remove `cancel(_ requestID:)` + now-unused helpers.
