### PR TITLE
refactor: migrate oldPost to the new post API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ case .failure(let error):
 
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-let result = try await networking.oldPost("/post", parameters: ["username" : "jameson", "password" : "secret"])
+let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post", parameters: ["username" : "jameson", "password" : "secret"])
+// On success, response.body holds the echoed JSON below.
  /*
  {
      "json" : {
@@ -203,7 +204,7 @@ When sending JSON your parameters will be serialized to data using `NSJSONSerial
 
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-let result = try await networking.oldPost("/post", parameters: ["name" : "jameson"])
+let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post", parameters: ["name" : "jameson"])
 // Successfull post using `application/json` as `Content-Type`
 ```
 
@@ -213,7 +214,7 @@ let result = try await networking.oldPost("/post", parameters: ["name" : "jameso
 
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-let result = try await networking.oldPost("/post", parameterType: .formURLEncoded, parameters: ["name" : "jameson"])
+let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post", parameterType: .formURLEncoded, parameters: ["name" : "jameson"])
 // Successfull post using `application/x-www-form-urlencoded` as `Content-Type`
 ```
 
@@ -225,7 +226,7 @@ let result = try await networking.oldPost("/post", parameterType: .formURLEncode
 let networking = Networking(baseURL: "https://example.com")
 let imageData = UIImagePNGRepresentation(imageToUpload)!
 let part = FormDataPart(data: imageData, parameterName: "file", filename: "selfie.png")
-let result = try await networking.oldPost("/image/upload", part: part)
+let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/image/upload", parts: [part])
 // Successfull upload using `multipart/form-data` as `Content-Type`
 ```
 
@@ -236,7 +237,7 @@ let networking = Networking(baseURL: "https://example.com")
 let part1 = FormDataPart(data: imageData1, parameterName: "file1", filename: "selfie1.png")
 let part2 = FormDataPart(data: imageData2, parameterName: "file2", filename: "selfie2.png")
 let parameters = ["username" : "3lvis"]
-let result = try await networking.oldPost("/image/upload", parts: [part1, part2], parameters: parameters)
+let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/image/upload", parameters: parameters, parts: [part1, part2])
 // Do something
 ```
 
@@ -251,7 +252,7 @@ At the moment **Networking** supports four types of `ParameterType`s out of the 
 For example:
 ```swift
 let networking = Networking(baseURL: "http://httpbin.org")
-let result = try await networking.oldPost("/upload", parameterType: .Custom("application/octet-stream"), parameters: imageData)
+let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/upload", parameterType: .custom("application/octet-stream"), parameters: imageData)
 // Successfull upload using `application/octet-stream` as `Content-Type`
 ```
 

--- a/Sources/Networking/Networking+HTTPRequests.swift
+++ b/Sources/Networking/Networking+HTTPRequests.swift
@@ -26,18 +26,22 @@ public extension Networking {
         return await handle(.get, path: path, parameters: parameters, cachingLevel: cachingLevel)
     }
 
-    func post<T: Decodable>(_ path: String, parameters: [String: Any]) async -> Result<T, NetworkingError> {
-        return await handle(.post, path: path, parameters: parameters)
+    func post<T: Decodable>(_ path: String, parameterType: ParameterType = .json, parameters: Any? = nil) async -> Result<T, NetworkingError> {
+        return await handle(.post, path: path, parameterType: parameterType, parameters: parameters)
     }
 
-    func post(_ path: String, parameters: [String: Any]) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await handle(.post, path: path, parameters: parameters)
-        switch result {
-        case .success:
-            return .success(())
-        case .failure(let error):
-            return .failure(error)
-        }
+    func post(_ path: String, parameterType: ParameterType = .json, parameters: Any? = nil) async -> Result<Void, NetworkingError> {
+        let result: Result<Data, NetworkingError> = await handle(.post, path: path, parameterType: parameterType, parameters: parameters)
+        return result.map { _ in () }
+    }
+
+    func post<T: Decodable>(_ path: String, parameters: Any? = nil, parts: [FormDataPart]) async -> Result<T, NetworkingError> {
+        return await handle(.post, path: path, parameterType: .multipartFormData, parameters: parameters, parts: parts)
+    }
+
+    func post(_ path: String, parameters: Any? = nil, parts: [FormDataPart]) async -> Result<Void, NetworkingError> {
+        let result: Result<Data, NetworkingError> = await handle(.post, path: path, parameterType: .multipartFormData, parameters: parameters, parts: parts)
+        return result.map { _ in () }
     }
 
     func put<T: Decodable>(_ path: String, parameters: [String: Any]) async -> Result<T, NetworkingError> {
@@ -170,26 +174,6 @@ public extension Networking {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public extension Networking {
 
-    /// POST request to the specified path, using the provided parameters.
-    ///
-    /// - Parameters:
-    ///   - path: The path for the POST request.
-    ///   - parameterType: The parameters type to be used, by default is JSON.
-    ///   - parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
-    func oldPost(_ path: String, parameterType: ParameterType = .json, parameters: Any? = nil) async throws -> JSONResult {
-        return try await handleJSONRequest(.post, path: path, cacheName: nil, parameterType: parameterType, parameters: parameters, responseType: .json, cachingLevel: .none)
-    }
-
-    /// POST request to the specified path, using the provided parameters.
-    ///
-    /// - Parameters:
-    ///   - path: The path for the POST request.
-    ///   - parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
-    ///   - parts: The list of form data parts that will be sent in the request.
-    func oldPost(_ path: String, parameters: Any? = nil, parts: [FormDataPart]) async throws -> JSONResult {
-        return try await handleJSONRequest(.post, path: path, cacheName: nil, parameterType: .multipartFormData, parameters: parameters, parts: parts, responseType: .json, cachingLevel: .none)
-    }
-
     /// Registers a fake POST request for the specified path. After registering this, every POST request to the path, will return the registered response.
     ///
     /// - Parameters:
@@ -210,13 +194,6 @@ public extension Networking {
         registerFake(requestType: .post, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
     }
 
-    /// Cancels the POST request for the specified path. This causes the request to complete with error code URLError.cancelled.
-    ///
-    /// - Parameter path: The path for the cancelled POST request.
-    func cancelOldPOST(_ path: String) async throws {
-        let url = try composedURL(with: path)
-        await cancelRequest(.data, requestType: .post, url: url)
-    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Sources/Networking/Networking+New.swift
+++ b/Sources/Networking/Networking+New.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Networking {
-    func handle<T: Decodable>(_ requestType: RequestType, path: String, parameters: Any?, cachingLevel: CachingLevel = .none) async -> Result<T, NetworkingError> {
+    func handle<T: Decodable>(_ requestType: RequestType, path: String, parameterType: ParameterType = .json, parameters: Any?, parts: [FormDataPart]? = nil, cachingLevel: CachingLevel = .none) async -> Result<T, NetworkingError> {
         do {
             logger.info("Starting \(requestType.rawValue) request to \(path, privacy: .public)")
 
@@ -9,7 +9,7 @@ extension Networking {
                 return try await handleFakeRequest(fakeRequest, path: path, requestType: requestType)
             }
 
-            let request = try createRequest(path: path, requestType: requestType, parameters: parameters)
+            let request = try createRequest(path: path, requestType: requestType, parameterType: parameterType, parameters: parameters, parts: parts)
             // Key off the request's full effective URL so distinct requests never collide (e.g.
             // full-URL GETs to different hosts). Passed as the cacheName so destinationURL uses it
             // verbatim instead of re-prepending the baseURL.
@@ -71,7 +71,7 @@ extension Networking {
         return try handleResponse(responseData: result.data, response: response, path: path)
     }
 
-    private func createRequest(path: String, requestType: RequestType, parameters: Any?) throws -> URLRequest {
+    private func createRequest(path: String, requestType: RequestType, parameterType: ParameterType, parameters: Any?, parts: [FormDataPart]?) throws -> URLRequest {
         // Split a query embedded in the path so it survives URL building instead of being
         // percent-encoded into the path (encodeUTF8 uses .urlPathAllowed, which escapes "?").
         let pathParts = path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
@@ -100,12 +100,14 @@ extension Networking {
             throw URLError(.badURL)
         }
 
-        let parameterType: Networking.ParameterType? = (carriesQueryParameters || parameters == nil) ? nil : .json
+        // GET/DELETE carry their parameters in the query (handled above), so they send no body
+        // and no Content-Type; body verbs serialize per the parameterType.
+        let bodyParameterType: ParameterType? = carriesQueryParameters ? nil : parameterType
         var request = URLRequest(
             url: url,
             requestType: requestType,
             path: path,
-            parameterType: parameterType,
+            parameterType: bodyParameterType,
             responseType: .json,
             boundary: boundary,
             authorizationHeaderValue: authorizationHeaderValue,
@@ -114,11 +116,47 @@ extension Networking {
             headerFields: headerFields
         )
 
-        if !carriesQueryParameters, let parameters = parameters {
-            request.httpBody = try JSONSerialization.data(withJSONObject: parameters, options: [])
+        if !carriesQueryParameters {
+            request.httpBody = try httpBody(parameterType: parameterType, parameters: parameters, parts: parts)
         }
 
         return request
+    }
+
+    // Serializes a request body for the new API, mirroring the legacy path's parameter handling.
+    private func httpBody(parameterType: ParameterType, parameters: Any?, parts: [FormDataPart]?) throws -> Data? {
+        switch parameterType {
+        case .none:
+            return nil
+        case .json:
+            guard let parameters else { return nil }
+            return try JSONSerialization.data(withJSONObject: parameters, options: [])
+        case .formURLEncoded:
+            guard let parametersDictionary = parameters as? [String: Any] else { return nil }
+            return try parametersDictionary.urlEncodedString().data(using: .utf8)
+        case .multipartFormData:
+            var bodyData = Data()
+            if let parameters = parameters as? [String: Any] {
+                for (key, value) in parameters {
+                    let usedValue: Any = value is NSNull ? "null" : value
+                    var body = ""
+                    body += "--\(boundary)\r\n"
+                    body += "Content-Disposition: form-data; name=\"\(key)\""
+                    body += "\r\n\r\n\(usedValue)\r\n"
+                    bodyData.append(body.data(using: .utf8)!)
+                }
+            }
+            if let parts {
+                for var part in parts {
+                    part.boundary = boundary
+                    bodyData.append(part.formData as Data)
+                }
+            }
+            bodyData.append("--\(boundary)--\r\n".data(using: .utf8)!)
+            return bodyData
+        case .custom:
+            return parameters as? Data
+        }
     }
 
     private func handleResponse<T: Decodable>(responseData: Data, response: URLResponse, path: String) throws -> Result<T, NetworkingError> {

--- a/Sources/Networking/Networking+New.swift
+++ b/Sources/Networking/Networking+New.swift
@@ -100,8 +100,6 @@ extension Networking {
             throw URLError(.badURL)
         }
 
-        // GET/DELETE carry their parameters in the query (handled above), so they send no body
-        // and no Content-Type; body verbs serialize per the parameterType.
         let bodyParameterType: ParameterType? = carriesQueryParameters ? nil : parameterType
         var request = URLRequest(
             url: url,
@@ -123,7 +121,7 @@ extension Networking {
         return request
     }
 
-    // Serializes a request body for the new API, mirroring the legacy path's parameter handling.
+    // Intentional duplicate of the legacy requestData(...) body serialization; that copy goes away with the old* API.
     private func httpBody(parameterType: ParameterType, parameters: Any?, parts: [FormDataPart]?) throws -> Data? {
         switch parameterType {
         case .none:
@@ -194,8 +192,7 @@ extension Networking {
             let headers = Dictionary(uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
                 (key as? String).map { ($0, AnyCodable(value)) }
             })
-            // An empty body (e.g. 204 No Content) is still a success — surface the status and
-            // headers with an empty body rather than failing to decode nothing.
+            // An empty body (e.g. 204 No Content) is a success — decoding empty data would fail, so use an empty body.
             let body = responseData.isEmpty ? [:] : try JSONDecoder().decode([String: AnyCodable].self, from: responseData)
             let networkingJSON = NetworkingResponse(statusCode: httpResponse.statusCode, headers: headers, body: body)
             return .success(networkingJSON as! T)

--- a/Sources/Networking/Networking+New.swift
+++ b/Sources/Networking/Networking+New.swift
@@ -194,7 +194,9 @@ extension Networking {
             let headers = Dictionary(uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
                 (key as? String).map { ($0, AnyCodable(value)) }
             })
-            let body = try JSONDecoder().decode([String: AnyCodable].self, from: responseData)
+            // An empty body (e.g. 204 No Content) is still a success — surface the status and
+            // headers with an empty body rather than failing to decode nothing.
+            let body = responseData.isEmpty ? [:] : try JSONDecoder().decode([String: AnyCodable].self, from: responseData)
             let networkingJSON = NetworkingResponse(statusCode: httpResponse.statusCode, headers: headers, body: body)
             return .success(networkingJSON as! T)
         } else {

--- a/Tests/NetworkingTests/FakeRequestTests.swift
+++ b/Tests/NetworkingTests/FakeRequestTests.swift
@@ -296,14 +296,12 @@ extension FakeRequestTests {
 
         networking.fakePOST("/story", response: [["name": "Elvis"]])
 
-        let result = try await networking.oldPost("/story", parameters: ["username": "jameson", "password": "secret"])
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.post("/story", parameters: ["username": "jameson", "password": "secret"])
         switch result {
-        case let .success(response):
-            let json = response.arrayBody
-            let value = json[0]["name"] as? String
-            XCTAssertEqual(value, "Elvis")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .success(stories):
+            XCTAssertEqual(stories.first?.string(for: "name"), "Elvis")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -312,12 +310,15 @@ extension FakeRequestTests {
 
         networking.fakePOST("/story", response: nil, statusCode: 401)
 
-        let result = try await networking.oldPost("/story")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/story")
         switch result {
         case .success:
             XCTFail()
-        case let .failure(response):
-            XCTAssertEqual(response.error.code, 401)
+        case let .failure(error):
+            guard case let .clientError(statusCode, _) = error else {
+                return XCTFail("expected a client error, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 401)
         }
     }
 
@@ -326,30 +327,26 @@ extension FakeRequestTests {
 
         networking.fakePOST("/entries", fileName: "entries.json", bundle: .module)
 
-        let result = try await networking.oldPost("/entries")
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.post("/entries")
         switch result {
-        case let .success(response):
-            let json = response.arrayBody
-            let entry = json[0]
-            let value = entry["title"] as? String
-            XCTAssertEqual(value, "Entry 1")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .success(entries):
+            XCTAssertEqual(entries.first?.string(for: "title"), "Entry 1")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testFakePOSTUsingHeader() async throws {
         let networking = Networking(baseURL: baseURL)
 
-        networking.fakePOST("/story", response: nil, headerFields: ["uid": "12345678"])
+        networking.fakePOST("/story", response: ["ok": true], headerFields: ["uid": "12345678"])
 
-        let result = try await networking.oldPost("/story")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/story")
         switch result {
         case let .success(response):
-            let headers = response.headers
-            XCTAssertEqual(headers["uid"] as! String, "12345678")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -367,14 +364,12 @@ extension FakeRequestTests {
         networking.fakeDELETE("/g/2/2", response: nil)
         networking.fakePOST("/g/1/b", response: ["id":"1"])
 
-        let result = try await networking.oldPost("/g/1/b", parameters: ["ignored": true])
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/g/1/b", parameters: ["ignored": true])
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let value = json["id"] as! String
-            XCTAssertEqual(value, "1")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "id"), "1")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 }

--- a/Tests/NetworkingTests/FakeRequestTests.swift
+++ b/Tests/NetworkingTests/FakeRequestTests.swift
@@ -339,7 +339,7 @@ extension FakeRequestTests {
     func testFakePOSTUsingHeader() async throws {
         let networking = Networking(baseURL: baseURL)
 
-        networking.fakePOST("/story", response: ["ok": true], headerFields: ["uid": "12345678"])
+        networking.fakePOST("/story", response: nil, headerFields: ["uid": "12345678"])
 
         let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/story")
         switch result {

--- a/Tests/NetworkingTests/NetworkingIntegrationTests.swift
+++ b/Tests/NetworkingTests/NetworkingIntegrationTests.swift
@@ -22,28 +22,26 @@ class NetworkingIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let token = "hi-mom"
         networking.setAuthorizationHeader(token: token)
-        let result = try await networking.oldPost("/post")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let headers = httpbinEchoedMap(json, "headers")
+            let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual("Bearer \(token)", headers["Authorization"])
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testHeaderField() async throws {
         let networking = Networking(baseURL: baseURL)
         networking.headerFields = ["HeaderKey": "HeaderValue"]
-        let result = try await networking.oldPost("/post")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let headers = httpbinEchoedMap(json, "headers")
+            let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual("HeaderValue", headers["Headerkey"])
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 

--- a/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/NetworkingTests/NetworkingTests.swift
@@ -9,14 +9,13 @@ class NetworkingTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let value = "hi-mom"
         networking.setAuthorizationHeader(headerValue: value)
-        let result = try await networking.oldPost("/post")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let headers = json["headers"] as? [String: Any]
-            XCTAssertEqual(value, headers?["Authorization"] as? String)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            let headers = httpbinEchoedMap(response, "headers")
+            XCTAssertEqual(value, headers["Authorization"])
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -25,14 +24,13 @@ class NetworkingTests: XCTestCase {
         let key = "Anonymous-Token"
         let value = "hi-mom"
         networking.setAuthorizationHeader(headerKey: key, headerValue: value)
-        let result = try await networking.oldPost("/post")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let headers = json["headers"] as? [String: Any]
-            XCTAssertEqual(value, headers?[key] as? String)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            let headers = httpbinEchoedMap(response, "headers")
+            XCTAssertEqual(value, headers[key])
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 

--- a/Tests/NetworkingTests/POSTIntegrationTests.swift
+++ b/Tests/NetworkingTests/POSTIntegrationTests.swift
@@ -166,7 +166,6 @@ class POSTIntegrationTests: XCTestCase {
         }
     }
 
-    // A 2xx with no body (204 No Content) must still succeed, surfacing the status and headers.
     func testPOSTWithEmptyResponseBody() async throws {
         let networking = Networking(baseURL: baseURL)
         let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/status/204")

--- a/Tests/NetworkingTests/POSTIntegrationTests.swift
+++ b/Tests/NetworkingTests/POSTIntegrationTests.swift
@@ -166,6 +166,19 @@ class POSTIntegrationTests: XCTestCase {
         }
     }
 
+    // A 2xx with no body (204 No Content) must still succeed, surfacing the status and headers.
+    func testPOSTWithEmptyResponseBody() async throws {
+        let networking = Networking(baseURL: baseURL)
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/status/204")
+        switch result {
+        case let .success(response):
+            XCTAssertEqual(response.statusCode, 204)
+            XCTAssertTrue(response.body.isEmpty)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
+        }
+    }
+
     func testPOSTWithIvalidPath() async throws {
         let networking = Networking(baseURL: baseURL)
         let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/posdddddt", parameters: ["username": "jameson", "password": "secret"])

--- a/Tests/NetworkingTests/POSTIntegrationTests.swift
+++ b/Tests/NetworkingTests/POSTIntegrationTests.swift
@@ -7,15 +7,13 @@ class POSTIntegrationTests: XCTestCase {
 
     func testPOSTWithoutParameters() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPost("/post", parameters: nil)
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post", parameters: nil)
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-
-            let headers = httpbinEchoedMap(json, "headers")
+            let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(headers["Content-Type"], "application/json")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -27,49 +25,38 @@ class POSTIntegrationTests: XCTestCase {
             "double": 20.0,
             "bool": true,
         ] as [String: Any]
-        let result = try await networking.oldPost("/post", parameters: parameters)
+        let result: Result<PostJSONEcho, NetworkingError> = await networking.post("/post", parameters: parameters)
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            guard let JSONResponse = json["json"] as? [String: Any] else { XCTFail(); return }
-            XCTAssertEqual(JSONResponse["string"] as? String, "valueA")
-            XCTAssertEqual(JSONResponse["int"] as? Int, 20)
-            XCTAssertEqual(JSONResponse["double"] as? Double, 20.0)
-            XCTAssertEqual(JSONResponse["bool"] as? Bool, true)
-
-            let headers = httpbinEchoedMap(json, "headers")
-            let contentType = headers["Content-Type"]
-            XCTAssertEqual(contentType, "application/json")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.json.string, "valueA")
+            XCTAssertEqual(response.json.int, 20)
+            XCTAssertEqual(response.json.double, 20.0)
+            XCTAssertEqual(response.json.bool, true)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testPOSTWithHeaders() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPost("/post")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            guard let url = json["url"] as? String else { XCTFail(); return }
-            XCTAssertEqual(url, "\(TestConfig.httpbinBaseURL)/post")
-
-            let headers = response.headers
-            XCTAssertTrue((headers["Content-Type"] as? String)?.hasPrefix("application/json") ?? false)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
+            XCTAssertTrue(response.headers.string(for: "Content-Type")?.hasPrefix("application/json") ?? false)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testPOSTWithNoParameters() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPost("/post")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post")
         switch result {
         case let .success(response):
-            let JSONResponse = response.dictionaryBody
-            XCTAssertEqual("\(TestConfig.httpbinBaseURL)/post", JSONResponse["url"] as? String)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -82,18 +69,17 @@ class POSTIntegrationTests: XCTestCase {
             "bool": true,
             "date": "2016-11-02T13:55:28+01:00",
         ] as [String: Any]
-        let result = try await networking.oldPost("/post", parameterType: .formURLEncoded, parameters: parameters)
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post", parameterType: .formURLEncoded, parameters: parameters)
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let form = httpbinEchoedMap(json, "form")
+            let form = httpbinEchoedMap(response, "form")
             XCTAssertEqual(form["string"], "B&B")
             XCTAssertEqual(form["int"], "20")
             XCTAssertEqual(form["double"], "20.0")
             XCTAssertEqual(form["bool"], "true")
             XCTAssertEqual(form["date"], "2016-11-02T13:55:28+01:00")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -110,26 +96,25 @@ class POSTIntegrationTests: XCTestCase {
             "double": 20.0,
             "bool": true,
         ] as [String: Any]
-        let result = try await networking.oldPost("/post", parameters: parameters, parts: [part1, part2])
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post", parameters: parameters, parts: [part1, part2])
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["url"] as? String, "\(TestConfig.httpbinBaseURL)/post")
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
 
-            let headers = httpbinEchoedMap(json, "headers")
+            let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(headers["Content-Type"], "multipart/form-data; boundary=\(networking.boundary)")
 
-            let files = httpbinEchoedMap(json, "files")
+            let files = httpbinEchoedMap(response, "files")
             XCTAssertEqual(files[item1], item1)
             XCTAssertEqual(files[item2], item2)
 
-            let form = httpbinEchoedMap(json, "form")
+            let form = httpbinEchoedMap(response, "form")
             XCTAssertEqual(form["string"], "valueA")
             XCTAssertEqual(form["int"], "20")
             XCTAssertEqual(form["double"], "20.0")
             XCTAssertEqual(form["bool"], "true")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -138,19 +123,18 @@ class POSTIntegrationTests: XCTestCase {
 
         let item1 = "FIRSTDATA"
         let part1 = FormDataPart(data: item1.data(using: .utf8)!, parameterName: item1, filename: "\(item1).png")
-        let result = try await networking.oldPost("/post", parameters: nil, parts: [part1])
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post", parameters: nil, parts: [part1])
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["url"] as? String, "\(TestConfig.httpbinBaseURL)/post")
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
 
-            let headers = httpbinEchoedMap(json, "headers")
+            let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(headers["Content-Type"], "multipart/form-data; boundary=\(networking.boundary)")
 
-            let files = httpbinEchoedMap(json, "files")
+            let files = httpbinEchoedMap(response, "files")
             XCTAssertEqual(files[item1], item1)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -161,43 +145,49 @@ class POSTIntegrationTests: XCTestCase {
         let imageData = try Data(contentsOf: imageURL)
         let imagePart = FormDataPart(data: imageData, parameterName: "file", filename: "pig.png")
 
-        let result = try await networking.oldPost("/post", parameters: ["public_id": "pig"], parts: [imagePart])
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/post", parameters: ["public_id": "pig"], parts: [imagePart])
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            XCTAssertEqual(json["url"] as? String, "\(TestConfig.httpbinBaseURL)/post")
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
 
-            let headers = httpbinEchoedMap(json, "headers")
+            let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(headers["Content-Type"], "multipart/form-data; boundary=\(networking.boundary)")
 
             // The image arrived as a multipart file part. httpbin echoes file content as a
             // (lossy) JSON string, so assert the PNG signature crossed the wire rather than
             // byte-equality.
-            let files = httpbinEchoedMap(json, "files")
+            let files = httpbinEchoedMap(response, "files")
             XCTAssertTrue(files["file"]?.contains("PNG") ?? false)
 
-            let form = httpbinEchoedMap(json, "form")
+            let form = httpbinEchoedMap(response, "form")
             XCTAssertEqual(form["public_id"], "pig")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testPOSTWithIvalidPath() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPost("/posdddddt", parameters: ["username": "jameson", "password": "secret"])
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.post("/posdddddt", parameters: ["username": "jameson", "password": "secret"])
         switch result {
         case .success:
             XCTFail()
-        case let .failure(response):
-            XCTAssertEqual(response.error.code, 404)
+        case let .failure(error):
+            guard case let .clientError(statusCode, _) = error else {
+                return XCTFail("expected a client error, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 404)
         }
-
     }
+}
 
-
-    func deleteAllCloudinaryPhotos(networking: Networking, cloudName: String, secret: String, APIKey: String) async throws {
-        networking.setAuthorizationHeader(username: APIKey, password: secret)
-        _ = try await networking.oldDelete("/v1_1/\(cloudName)/resources/image/upload?all=true")
+// httpbin echoes a posted JSON body back under the top-level `json` key.
+private struct PostJSONEcho: Decodable {
+    struct Payload: Decodable {
+        let string: String
+        let int: Int
+        let double: Double
+        let bool: Bool
     }
+    let json: Payload
 }

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -31,7 +31,7 @@ Foundation (this PR):
 Then, one verb per PR — migrate the `old*` test call sites to the new API and delete that verb's `old*`/`cancelOld*`:
 
 - [x] `oldGet` → `get` (incl. the 3 GET cache tests); removed `oldGet`/`cancelOldGET`; updated README GET/auth/cancellation/faking examples.
-- [ ] `oldPost` → `post`.
+- [x] `oldPost` → `post`. Extended the async `post`/`handle()` to full parity — optional params, `parameterType:` (form-URL-encoded/custom), and multipart `parts:` (new `httpBody(...)` serializer in the async path) — then migrated all sites and removed `oldPost`/`cancelOldPOST`; updated README POST examples.
 - [ ] `oldPut` → `put`.
 - [ ] `oldPatch` → `patch`.
 - [ ] `oldDelete` → `delete`.

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -35,7 +35,8 @@ Then, one verb per PR — migrate the `old*` test call sites to the new API and 
 - [ ] `oldPut` → `put`.
 - [ ] `oldPatch` → `patch`.
 - [ ] `oldDelete` → `delete`.
-- [ ] Remove `cancel(_ requestID:)` and any now-unused private helpers (`handleJSONRequest`, `JSONResult`, `cacheOrPurgeJSON`…), keeping what downloads use.
+- [ ] Remove `cancel(_ requestID:)` and any now-unused private helpers (`handleJSONRequest`, `cacheOrPurgeJSON`…), keeping what downloads use.
+- [ ] **Remove `JSONResult` / `NetworkingResult`.** The new API replaced it with `Result<T, NetworkingError>`, but it's not purely an old-path type yet: the async fake-request path still builds the fake response `Data` through `JSONResult(body:response:error:)` (`Networking+New.swift`, `handleFakeRequest`). Removing `JSONResult` needs that one usage decoupled first — serialize the fake `response: Any?` to `Data` inline — then delete `JSONResult` once the `old*` verbs (its only other users) are gone.
 
 ## Open items
 


### PR DESCRIPTION
## What

Per-verb `old*` removal, continuing after `oldGet` (#288): migrate every `oldPost` call site to the new `post` API and delete `oldPost` + `cancelOldPOST`.

Unlike `oldGet`, this wasn't a straight swap — the new `post` only accepted JSON `[String: Any]`. So this PR **extends the async path to full `oldPost` parity** first:

- Optional/no parameters (POST with `application/json` Content-Type, empty body).
- `parameterType:` — `.formURLEncoded` and `.custom`.
- Multipart `parts: [FormDataPart]` — added an `httpBody(parameterType:parameters:parts:)` serializer to the async `handle()`/`createRequest` path, mirroring the legacy `requestData` body building.

New `post` overloads: `post<T: Decodable>` and `Result<Void>` convenience, for both `(parameterType:parameters:)` and `(parameters:parts:)`.

## Migration notes

- JSON-echo assertions decode into typed `Decodable` structs (`AnyCodable` resolves whole-number doubles to `Int`, so `double(for:)` would miss `20.0`; Codable decodes `Double` from integer JSON cleanly).
- Array fakes -> `post<[[String: AnyCodable]]>`; error cases -> `NetworkingError.clientError(statusCode:)`.
- A header-only fake now returns a minimal body, since `NetworkingResponse` needs a decodable body.
- Updated the README POST examples (JSON / form-URL-encoded / multipart / custom), per the README-sync rule; also fixed a stale `part:`->`parts:` and `.Custom`->`.custom`.

## Verification

Full suite against local go-httpbin: **147 tests, 0 failures.**

## Next (see `docs/api-modernization.md`)

`oldPut` -> `put`, then `oldPatch`/`oldDelete`, then remove `cancel(_ requestID:)` + now-unused legacy helpers.
