### PR TITLE
refactor: migrate oldPut to the new put API

### DIFF
--- a/Sources/Networking/Networking+HTTPRequests.swift
+++ b/Sources/Networking/Networking+HTTPRequests.swift
@@ -44,18 +44,13 @@ public extension Networking {
         return result.map { _ in () }
     }
 
-    func put<T: Decodable>(_ path: String, parameters: [String: Any]) async -> Result<T, NetworkingError> {
-        return await handle(.put, path: path, parameters: parameters)
+    func put<T: Decodable>(_ path: String, parameterType: ParameterType = .json, parameters: Any? = nil) async -> Result<T, NetworkingError> {
+        return await handle(.put, path: path, parameterType: parameterType, parameters: parameters)
     }
 
-    func put(_ path: String, parameters: [String: Any]) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await handle(.put, path: path, parameters: parameters)
-        switch result {
-        case .success:
-            return .success(())
-        case .failure(let error):
-            return .failure(error)
-        }
+    func put(_ path: String, parameterType: ParameterType = .json, parameters: Any? = nil) async -> Result<Void, NetworkingError> {
+        let result: Result<Data, NetworkingError> = await handle(.put, path: path, parameterType: parameterType, parameters: parameters)
+        return result.map { _ in () }
     }
 
     func patch<T: Decodable>(_ path: String, parameters: [String: Any]) async -> Result<T, NetworkingError> {
@@ -132,16 +127,6 @@ public extension Networking {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public extension Networking {
 
-    /// PUT request to the specified path, using the provided parameters.
-    ///
-    /// - Parameters:
-    ///   - path: The path for the PUT request.
-    ///   - parameterType: The parameters type to be used, by default is JSON.
-    ///   - parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
-    func oldPut(_ path: String, parameterType: ParameterType = .json, parameters: Any? = nil) async throws -> JSONResult {
-        return try await handleJSONRequest(.put, path: path, cacheName: nil, parameterType: parameterType, parameters: parameters, responseType: .json, cachingLevel: .none)
-    }
-
     /// Registers a fake PUT request for the specified path. After registering this, every PUT request to the path, will return the registered response.
     ///
     /// - Parameters:
@@ -162,13 +147,6 @@ public extension Networking {
         registerFake(requestType: .put, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
     }
 
-    /// Cancels the PUT request for the specified path. This causes the request to complete with error code URLError.cancelled.
-    ///
-    /// - Parameter path: The path for the cancelled PUT request.
-    func cancelOldPUT(_ path: String) async throws {
-        let url = try composedURL(with: path)
-        await cancelRequest(.data, requestType: .put, url: url)
-    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/NetworkingTests/FakeRequestTests.swift
+++ b/Tests/NetworkingTests/FakeRequestTests.swift
@@ -381,14 +381,12 @@ extension FakeRequestTests {
 
         networking.fakePUT("/story", response: [["name": "Elvis"]])
 
-        let result = try await networking.oldPut("/story", parameters: ["username": "jameson", "password": "secret"])
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.put("/story", parameters: ["username": "jameson", "password": "secret"])
         switch result {
-        case let .success(response):
-            let json = response.arrayBody
-            let value = json[0]["name"] as? String
-            XCTAssertEqual(value, "Elvis")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .success(stories):
+            XCTAssertEqual(stories.first?.string(for: "name"), "Elvis")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -397,12 +395,15 @@ extension FakeRequestTests {
 
         networking.fakePUT("/story", response: nil, statusCode: 401)
 
-        let result = try await networking.oldPut("/story", parameters: nil)
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.put("/story")
         switch result {
         case .success:
             XCTFail()
-        case let .failure(response):
-            XCTAssertEqual(response.error.code, 401)
+        case let .failure(error):
+            guard case let .clientError(statusCode, _) = error else {
+                return XCTFail("expected a client error, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 401)
         }
     }
 
@@ -411,15 +412,12 @@ extension FakeRequestTests {
 
         networking.fakePUT("/entries", fileName: "entries.json", bundle: .module)
 
-        let result = try await networking.oldPut("/entries", parameters: nil)
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.put("/entries")
         switch result {
-        case let .success(response):
-            let json = response.arrayBody
-            let entry = json[0]
-            let value = entry["title"] as? String
-            XCTAssertEqual(value, "Entry 1")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .success(entries):
+            XCTAssertEqual(entries.first?.string(for: "title"), "Entry 1")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -428,13 +426,12 @@ extension FakeRequestTests {
 
         networking.fakePUT("/story", response: nil, headerFields: ["uid": "12345678"])
 
-        let result = try await networking.oldPut("/story")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.put("/story")
         switch result {
         case let .success(response):
-            let headers = response.headers
-            XCTAssertEqual(headers["uid"] as! String, "12345678")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 }

--- a/Tests/NetworkingTests/PUTIntegrationTests.swift
+++ b/Tests/NetworkingTests/PUTIntegrationTests.swift
@@ -7,46 +7,43 @@ class PUTIntegrationTests: XCTestCase {
 
     func testPUT() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPut("/put", parameters: ["username": "jameson", "password": "secret"])
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.put("/put", parameters: ["username": "jameson", "password": "secret"])
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let JSONResponse = json["json"] as? [String: String]
-            XCTAssertEqual("jameson", JSONResponse?["username"])
-            XCTAssertEqual("secret", JSONResponse?["password"])
+            let json = httpbinEchoedMap(response, "json")
+            XCTAssertEqual(json["username"], "jameson")
+            XCTAssertEqual(json["password"], "secret")
 
-            let headers = httpbinEchoedMap(json, "headers")
+            let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(headers["Content-Type"], "application/json")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testPUTWithHeaders() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPut("/put")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.put("/put")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            guard let url = json["url"] as? String else { XCTFail(); return }
-            XCTAssertEqual(url, "\(TestConfig.httpbinBaseURL)/put")
-
-            let headers = response.headers
-            XCTAssertTrue((headers["Content-Type"] as? String)?.hasPrefix("application/json") ?? false)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/put")
+            XCTAssertTrue(response.headers.string(for: "Content-Type")?.hasPrefix("application/json") ?? false)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testPUTWithIvalidPath() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPut("/posdddddt", parameters: ["username": "jameson", "password": "secret"])
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.put("/posdddddt", parameters: ["username": "jameson", "password": "secret"])
         switch result {
         case .success:
             XCTFail()
-        case let .failure(response):
-            XCTAssertEqual(response.error.code, 404)
+        case let .failure(error):
+            guard case let .clientError(statusCode, _) = error else {
+                return XCTFail("expected a client error, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 404)
         }
     }
-
 }

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -32,7 +32,7 @@ Then, one verb per PR — migrate the `old*` test call sites to the new API and 
 
 - [x] `oldGet` → `get` (incl. the 3 GET cache tests); removed `oldGet`/`cancelOldGET`; updated README GET/auth/cancellation/faking examples.
 - [x] `oldPost` → `post`. Extended the async `post`/`handle()` to full parity — optional params, `parameterType:` (form-URL-encoded/custom), and multipart `parts:` (new `httpBody(...)` serializer in the async path) — then migrated all sites and removed `oldPost`/`cancelOldPOST`; updated README POST examples.
-- [ ] `oldPut` → `put`.
+- [x] `oldPut` → `put`. Extended `put` to `parameterType:`/optional params (reusing the `handle()` body path from the POST work; no multipart — `oldPut` had none); migrated all sites and removed `oldPut`/`cancelOldPUT`. No README PUT examples to update.
 - [ ] `oldPatch` → `patch`.
 - [ ] `oldDelete` → `delete`.
 - [ ] Remove `cancel(_ requestID:)` and any now-unused private helpers (`handleJSONRequest`, `cacheOrPurgeJSON`…), keeping what downloads use.


### PR DESCRIPTION
## What

Per-verb `old*` removal, continuing after `oldGet` (#288) and `oldPost` (#290): migrate every `oldPut` call site to the new `put` API and delete `oldPut` + `cancelOldPUT`.

Smaller than the POST migration — the `handle()` body path already supports `parameterType:`/optional params (added in #290), and `oldPut` had no multipart `parts:` variant. So `put` just gains the parity overloads:

- `put<T: Decodable>(_:parameterType:parameters:)` and the `Result<Void>` convenience, with `parameterType: ParameterType = .json, parameters: Any? = nil`.

## Changes

- Migrated all `oldPut` sites (3 integration + 4 fakes) to `put(...) -> Result<…, NetworkingError>` + `NetworkingResponse`/typed decoding.
- Removed `oldPut` and `cancelOldPUT`.
- No README PUT examples existed to update.
- The header-only fake (`response: nil`) works via the empty-body fix already on master (#290).

## Verification

Full suite against local go-httpbin: **148 tests, 0 failures.**

## Next (see `docs/api-modernization.md`)

`oldPatch` -> `patch`, then `oldDelete` -> `delete`, then remove `cancel(_ requestID:)` and `JSONResult` (decoupling the async fake path first).
