### PR TITLE
refactor: migrate oldPatch to the new patch API

### DIFF
--- a/Sources/Networking/Networking+HTTPRequests.swift
+++ b/Sources/Networking/Networking+HTTPRequests.swift
@@ -53,18 +53,13 @@ public extension Networking {
         return result.map { _ in () }
     }
 
-    func patch<T: Decodable>(_ path: String, parameters: [String: Any]) async -> Result<T, NetworkingError> {
-        return await handle(.patch, path: path, parameters: parameters)
+    func patch<T: Decodable>(_ path: String, parameterType: ParameterType = .json, parameters: Any? = nil) async -> Result<T, NetworkingError> {
+        return await handle(.patch, path: path, parameterType: parameterType, parameters: parameters)
     }
 
-    func patch(_ path: String, parameters: [String: Any]) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await handle(.patch, path: path, parameters: parameters)
-        switch result {
-        case .success:
-            return .success(())
-        case .failure(let error):
-            return .failure(error)
-        }
+    func patch(_ path: String, parameterType: ParameterType = .json, parameters: Any? = nil) async -> Result<Void, NetworkingError> {
+        let result: Result<Data, NetworkingError> = await handle(.patch, path: path, parameterType: parameterType, parameters: parameters)
+        return result.map { _ in () }
     }
 
     func delete(_ path: String) async -> Result<Void, NetworkingError> {
@@ -84,16 +79,6 @@ public extension Networking {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public extension Networking {
-
-    /// PATCH request to the specified path, using the provided parameters.
-    ///
-    /// - Parameters:
-    ///   - path: The path for the PATCH request.
-    ///   - parameterType: The parameters type to be used, by default is JSON.
-    ///   - parameters: The parameters to be used, they will be serialized using the ParameterType, by default this is JSON.
-    func oldPatch(_ path: String, parameterType: ParameterType = .json, parameters: Any? = nil) async throws -> JSONResult {
-        return try await handleJSONRequest(.patch, path: path, cacheName: nil, parameterType: parameterType, parameters: parameters, responseType: .json, cachingLevel: .none)
-    }
 
     /// Registers a fake PATCH request for the specified path. After registering this, every PATCH request to the path, will return the registered response.
     ///
@@ -115,13 +100,6 @@ public extension Networking {
         registerFake(requestType: .patch, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
     }
 
-    /// Cancels the PATCH request for the specified path. This causes the request to complete with error code URLError.cancelled.
-    ///
-    /// - Parameter path: The path for the cancelled PATCH request.
-    func cancelOldPATCH(_ path: String) async throws {
-        let url = try composedURL(with: path)
-        await cancelRequest(.data, requestType: .patch, url: url)
-    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/Tests/NetworkingTests/FakeRequestTests.swift
+++ b/Tests/NetworkingTests/FakeRequestTests.swift
@@ -443,14 +443,12 @@ extension FakeRequestTests {
 
         networking.fakePATCH("/story", response: [["name": "Elvis"]])
 
-        let result = try await networking.oldPatch("/story", parameters: ["username": "jameson", "password": "secret"])
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.patch("/story", parameters: ["username": "jameson", "password": "secret"])
         switch result {
-        case let .success(response):
-            let json = response.arrayBody
-            let value = json[0]["name"] as? String
-            XCTAssertEqual(value, "Elvis")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .success(stories):
+            XCTAssertEqual(stories.first?.string(for: "name"), "Elvis")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -459,12 +457,15 @@ extension FakeRequestTests {
 
         networking.fakePATCH("/story", response: nil, statusCode: 401)
 
-        let result = try await networking.oldPatch("/story", parameters: nil)
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.patch("/story")
         switch result {
         case .success:
             XCTFail()
-        case let .failure(response):
-            XCTAssertEqual(response.error.code, 401)
+        case let .failure(error):
+            guard case let .clientError(statusCode, _) = error else {
+                return XCTFail("expected a client error, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 401)
         }
     }
 
@@ -473,15 +474,12 @@ extension FakeRequestTests {
 
         networking.fakePATCH("/entries", fileName: "entries.json", bundle: .module)
 
-        let result = try await networking.oldPatch("/entries", parameters: nil)
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.patch("/entries")
         switch result {
-        case let .success(response):
-            let json = response.arrayBody
-            let entry = json[0]
-            let value = entry["title"] as? String
-            XCTAssertEqual(value, "Entry 1")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .success(entries):
+            XCTAssertEqual(entries.first?.string(for: "title"), "Entry 1")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
@@ -490,13 +488,12 @@ extension FakeRequestTests {
 
         networking.fakePATCH("/story", response: nil, headerFields: ["uid": "12345678"])
 
-        let result = try await networking.oldPatch("/story")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.patch("/story")
         switch result {
         case let .success(response):
-            let headers = response.headers
-            XCTAssertEqual(headers["uid"] as! String, "12345678")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 }

--- a/Tests/NetworkingTests/PATCHIntegrationTests.swift
+++ b/Tests/NetworkingTests/PATCHIntegrationTests.swift
@@ -7,47 +7,43 @@ class PATCHIntegrationTests: XCTestCase {
 
     func testPATCH() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPatch("/patch", parameters: ["username": "jameson", "password": "secret"])
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.patch("/patch", parameters: ["username": "jameson", "password": "secret"])
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            let JSONResponse = json["json"] as? [String: String]
-            XCTAssertEqual("jameson", JSONResponse?["username"])
-            XCTAssertEqual("secret", JSONResponse?["password"])
+            let json = httpbinEchoedMap(response, "json")
+            XCTAssertEqual(json["username"], "jameson")
+            XCTAssertEqual(json["password"], "secret")
 
-            let headers = httpbinEchoedMap(json, "headers")
+            let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(headers["Content-Type"], "application/json")
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testPATCHWithHeaders() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPatch("/patch")
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.patch("/patch")
         switch result {
         case let .success(response):
-            let json = response.dictionaryBody
-            guard let url = json["url"] as? String else { XCTFail(); return }
-            XCTAssertEqual(url, "\(TestConfig.httpbinBaseURL)/patch")
-
-            let headers = response.headers
-            XCTAssertTrue((headers["Content-Type"] as? String)?.hasPrefix("application/json") ?? false)
-        case let .failure(response):
-            XCTFail(response.error.localizedDescription)
+            XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/patch")
+            XCTAssertTrue(response.headers.string(for: "Content-Type")?.hasPrefix("application/json") ?? false)
+        case let .failure(error):
+            XCTFail(error.localizedDescription)
         }
     }
 
     func testPATCHWithIvalidPath() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result = try await networking.oldPatch("/posdddddt", parameters: ["username": "jameson", "password": "secret"])
+        let result: Result<NetworkingResponse, NetworkingError> = await networking.patch("/posdddddt", parameters: ["username": "jameson", "password": "secret"])
         switch result {
         case .success:
             XCTFail()
-        case let .failure(response):
-            XCTAssertEqual(response.error.code, 404)
+        case let .failure(error):
+            guard case let .clientError(statusCode, _) = error else {
+                return XCTFail("expected a client error, got \(error)")
+            }
+            XCTAssertEqual(statusCode, 404)
         }
     }
-
 }
-

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -33,7 +33,7 @@ Then, one verb per PR — migrate the `old*` test call sites to the new API and 
 - [x] `oldGet` → `get` (incl. the 3 GET cache tests); removed `oldGet`/`cancelOldGET`; updated README GET/auth/cancellation/faking examples.
 - [x] `oldPost` → `post`. Extended the async `post`/`handle()` to full parity — optional params, `parameterType:` (form-URL-encoded/custom), and multipart `parts:` (new `httpBody(...)` serializer in the async path) — then migrated all sites and removed `oldPost`/`cancelOldPOST`; updated README POST examples.
 - [x] `oldPut` → `put`. Extended `put` to `parameterType:`/optional params (reusing the `handle()` body path from the POST work; no multipart — `oldPut` had none); migrated all sites and removed `oldPut`/`cancelOldPUT`. No README PUT examples to update.
-- [ ] `oldPatch` → `patch`.
+- [x] `oldPatch` → `patch`. Same shape as PUT — extended `patch` to `parameterType:`/optional params (no multipart), migrated all sites, removed `oldPatch`/`cancelOldPATCH`. No README PATCH examples to update.
 - [ ] `oldDelete` → `delete`.
 - [ ] Remove `cancel(_ requestID:)` and any now-unused private helpers (`handleJSONRequest`, `cacheOrPurgeJSON`…), keeping what downloads use.
 - [ ] **Remove `JSONResult` / `NetworkingResult`.** The new API replaced it with `Result<T, NetworkingError>`, but it's not purely an old-path type yet: the async fake-request path still builds the fake response `Data` through `JSONResult(body:response:error:)` (`Networking+New.swift`, `handleFakeRequest`). Removing `JSONResult` needs that one usage decoupled first — serialize the fake `response: Any?` to `Data` inline — then delete `JSONResult` once the `old*` verbs (its only other users) are gone.


### PR DESCRIPTION
## What

Per-verb `old*` removal, continuing after `oldGet` (#288), `oldPost` (#290), `oldPut` (#291): migrate every `oldPatch` call site to the new `patch` API and delete `oldPatch` + `cancelOldPATCH`.

Same shape as the PUT migration — the `handle()` body path already supports `parameterType:`/optional params, and `oldPatch` had no multipart. So `patch` gains the parity overloads (`patch<T>` + `Result<Void>`, with `parameterType: ParameterType = .json, parameters: Any? = nil`).

## Changes

- Migrated all `oldPatch` sites (3 integration + 4 fakes) to `patch(...) -> Result<…, NetworkingError>` + `NetworkingResponse`/typed decoding.
- Removed `oldPatch` and `cancelOldPATCH`.
- No README PATCH examples existed to update.

## Verification

Full suite against local go-httpbin: **148 tests, 0 failures.**

## Next (see `docs/api-modernization.md`)

`oldDelete` -> `delete` (last verb), then remove `cancel(_ requestID:)` and `JSONResult` (decoupling the async fake path first).
