### PR TITLE
test: purge httpbin.org repo-wide; add make test for local go-httpbin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: xcodebuild -version && swift --version
 
       # Integration tests run against a local go-httpbin rather than the public
-      # httpbin.org (which rate-limits to HTTP 503 under load). go-httpbin is a faithful
+      # httpbin service (which rate-limits to HTTP 503 under load). go-httpbin is a faithful
       # native reimplementation, so tests still exercise the full real HTTP stack.
       - name: Start go-httpbin
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# The integration tests run against a local go-httpbin (https://github.com/mccutchen/go-httpbin),
+# the same backend CI uses. `make test` spins one up in Docker, runs the suite, and tears it down.
+# To iterate, run `make httpbin` once and then `swift test` as many times as you like.
+# Requires Docker. The offline/faked test suites need no server.
+
+HTTPBIN_CONTAINER := networking-go-httpbin
+HTTPBIN_URL := http://127.0.0.1:8080
+
+.PHONY: test httpbin httpbin-stop
+
+test: httpbin
+	@HTTPBIN_BASE_URL=$(HTTPBIN_URL) swift test; status=$$?; \
+		$(MAKE) httpbin-stop; \
+		exit $$status
+
+httpbin:
+	@docker rm -f $(HTTPBIN_CONTAINER) >/dev/null 2>&1 || true
+	@docker run -d --name $(HTTPBIN_CONTAINER) -p 8080:8080 mccutchen/go-httpbin >/dev/null
+	@until curl -sf $(HTTPBIN_URL)/get >/dev/null 2>&1; do sleep 0.2; done
+	@echo "go-httpbin is up at $(HTTPBIN_URL)"
+
+httpbin-stop:
+	@docker rm -f $(HTTPBIN_CONTAINER) >/dev/null 2>&1 || true

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,13 @@ test: httpbin
 httpbin:
 	@docker rm -f $(HTTPBIN_CONTAINER) >/dev/null 2>&1 || true
 	@docker run -d --name $(HTTPBIN_CONTAINER) -p 8080:8080 mccutchen/go-httpbin >/dev/null
-	@until curl -sf $(HTTPBIN_URL)/get >/dev/null 2>&1; do sleep 0.2; done
-	@echo "go-httpbin is up at $(HTTPBIN_URL)"
+	@for i in $$(seq 1 30); do \
+		curl -sf $(HTTPBIN_URL)/get >/dev/null 2>&1 && echo "go-httpbin is up at $(HTTPBIN_URL)" && exit 0; \
+		sleep 0.5; \
+	done; \
+	echo "go-httpbin did not become reachable at $(HTTPBIN_URL) within 15s"; \
+	$(MAKE) httpbin-stop; \
+	exit 1
 
 httpbin-stop:
 	@docker rm -f $(HTTPBIN_CONTAINER) >/dev/null 2>&1 || true

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Initializing an instance of **Networking** means you have to select a [URLSessio
 
 ```swift
 // Default
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 
 // Ephemeral
-let networking = Networking(baseURL: "http://httpbin.org", configuration: .ephemeral)
+let networking = Networking(baseURL: "http://example.com", configuration: .ephemeral)
 ```
 
 ## Changing request headers
@@ -73,7 +73,7 @@ networking.headerFields = ["User-Agent": "your new user agent"]
 To authenticate using [basic authentication](http://www.w3.org/Protocols/HTTP/1.0/spec.html#BasicAA) with a username **"aladdin"** and password **"opensesame"** you only need to do this:
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 networking.setAuthorizationHeader(username: "aladdin", password: "opensesame")
 let result: Result<JSONResponse, NetworkingError> = await networking.get("/basic-auth/aladdin/opensesame")
 // Successfully authenticated!
@@ -84,7 +84,7 @@ let result: Result<JSONResponse, NetworkingError> = await networking.get("/basic
 To authenticate using a [bearer token](https://tools.ietf.org/html/rfc6750) **"AAAFFAAAA3DAAAAAA"** you only need to do this:
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 networking.setAuthorizationHeader(token: "AAAFFAAAA3DAAAAAA")
 let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
 // Successfully authenticated!
@@ -95,7 +95,7 @@ let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
 To authenticate using a custom authentication header, for example **"Token token=AAAFFAAAA3DAAAAAA"** you would need to set the following header field: `Authorization: Token token=AAAFFAAAA3DAAAAAA`. Luckily, **Networking** provides a simple way to do this:
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 networking.setAuthorizationHeader(headerValue: "Token token=AAAFFAAAA3DAAAAAA")
 let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
 // Successfully authenticated!
@@ -104,7 +104,7 @@ let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
 Providing the following authentication header `Anonymous-Token: AAAFFAAAA3DAAAAAA` is also possible:
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 networking.setAuthorizationHeader(headerKey: "Anonymous-Token", headerValue: "AAAFFAAAA3DAAAAAA")
 let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
 // Successfully authenticated!
@@ -119,7 +119,7 @@ Making a request is as simple as just calling `get`, `post`, `put`, or `delete`.
 **GET example**:
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
 switch result {
 case .success(let response):
@@ -133,7 +133,7 @@ case .failure(let error):
 **POST example**:
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let result: Result<JSONResponse, NetworkingError> = await networking.post("/post", parameters: ["username" : "jameson", "password" : "secret"])
 // On success, response.body holds the echoed JSON below.
  /*
@@ -142,12 +142,12 @@ let result: Result<JSONResponse, NetworkingError> = await networking.post("/post
          "username" : "jameson",
          "password" : "secret"
      },
-     "url" : "http://httpbin.org/post",
+     "url" : "http://example.com/post",
      "data" : "{"password" : "secret","username" : "jameson"}",
      "headers" : {
          "Accept" : "application/json",
          "Content-Type" : "application/json",
-         "Host" : "httpbin.org",
+         "Host" : "example.com",
          "Content-Length" : "44",
          "Accept-Language" : "en-us"
      }
@@ -158,7 +158,7 @@ let result: Result<JSONResponse, NetworkingError> = await networking.post("/post
 You can get the response headers and status code inside the success.
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
 switch result {
 case .success(let response):
@@ -203,7 +203,7 @@ The `Content-Type` HTTP specification is so unfriendly, you have to know the spe
 When sending JSON your parameters will be serialized to data using `NSJSONSerialization`.
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let result: Result<JSONResponse, NetworkingError> = await networking.post("/post", parameters: ["name" : "jameson"])
 // Successfull post using `application/json` as `Content-Type`
 ```
@@ -213,7 +213,7 @@ let result: Result<JSONResponse, NetworkingError> = await networking.post("/post
  If you want to use `application/x-www-form-urlencoded` just use the `.formURLEncoded` parameter type, internally **Networking** will format your parameters so they use [`Percent-encoding` or `URL-enconding`](https://en.wikipedia.org/wiki/Percent-encoding#The_application.2Fx-www-form-urlencoded_type).
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let result: Result<JSONResponse, NetworkingError> = await networking.post("/post", parameterType: .formURLEncoded, parameters: ["name" : "jameson"])
 // Successfull post using `application/x-www-form-urlencoded` as `Content-Type`
 ```
@@ -251,7 +251,7 @@ At the moment **Networking** supports four types of `ParameterType`s out of the 
 
 For example:
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let result: Result<JSONResponse, NetworkingError> = await networking.post("/upload", parameterType: .custom("application/octet-stream"), parameters: imageData)
 // Successfull upload using `application/octet-stream` as `Content-Type`
 ```
@@ -261,7 +261,7 @@ let result: Result<JSONResponse, NetworkingError> = await networking.post("/uplo
 Hold the `Task` running the request and call `cancel()` on it. A cancelled request fails with `NetworkingError.cancelled`.
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let task = Task {
     let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
     // On cancellation this is .failure(.cancelled)
@@ -313,7 +313,7 @@ let result: Result<JSONResponse, NetworkingError> = await networking.get("/stori
 **Downloading**:
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let result: Result<Image, NetworkingError> = await networking.downloadImage("/image/png")
 switch result {
 case .success(let image):
@@ -348,7 +348,7 @@ try await networking.cancelImageDownload("/image/png")
 **Networking** uses a multi-cache architecture when downloading images, the first time the `downloadImage` method is called for a specific path, it will store the results in disk (Documents folder) and in memory (NSCache), so in the next call it will return the cached results without hitting the network.
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let _: Result<Image, NetworkingError> = await networking.downloadImage("/image/png")
 // Image from network
 
@@ -359,7 +359,7 @@ let _: Result<Image, NetworkingError> = await networking.downloadImage("/image/p
 If you want to remove the downloaded image you can do it like this:
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 let destinationURL = try networking.destinationURL(for: "/image/png")
 if FileManager.default.fileExists(atPath: destinationURL.path) {
     try FileManager.default.removeItem(at: destinationURL)
@@ -399,7 +399,7 @@ A 404 request will print something like this:
 
 Error 404: Error Domain=NetworkingErrorDomain Code=404 "not found" UserInfo={NSLocalizedDescription=not found}
 
-URL: http://httpbin.org/posdddddt
+URL: http://example.com/posdddddt
 
 Headers: ["Accept": "application/json", "Content-Type": "application/json"]
 
@@ -426,13 +426,31 @@ Status code: 404 — not found
 To disable error logging use the flag `disableErrorLogging`.
 
 ```swift
-let networking = Networking(baseURL: "http://httpbin.org")
+let networking = Networking(baseURL: "http://example.com")
 networking.disableErrorLogging = true
 ```
 
 ## Installing
 
 **Networking** is available through Swift Package Manager.
+
+## Running the tests
+
+The integration tests exercise the real HTTP stack against a local [go-httpbin](https://github.com/mccutchen/go-httpbin) — the same backend CI uses. With [Docker](https://www.docker.com) installed:
+
+```shell
+make test   # starts go-httpbin, runs the suite, tears it down
+```
+
+To iterate, start it once and run the suite directly:
+
+```shell
+make httpbin      # leaves go-httpbin running on :8080
+swift test
+make httpbin-stop
+```
+
+Tests default to `http://127.0.0.1:8080`; set `HTTPBIN_BASE_URL` to point elsewhere. The offline (faked) suites need no server.
 
 ## Author
 

--- a/Tests/NetworkingTests/FakeRequestTests.swift
+++ b/Tests/NetworkingTests/FakeRequestTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Networking
 
 class FakeRequestTests: XCTestCase {
-    let baseURL = "http://httpbin.org"
+    let baseURL = TestConfig.httpbinBaseURL
 
     func testRemoveFirstLetterIfDash() {
         var evaluated = "/"

--- a/Tests/NetworkingTests/GETTests.swift
+++ b/Tests/NetworkingTests/GETTests.swift
@@ -8,7 +8,7 @@ struct Friend: Decodable {
 }
 
 class GETTests: XCTestCase {
-    let baseURL = "http://httpbin.org"
+    let baseURL = TestConfig.httpbinBaseURL
 
     func testGETCachedFromMemory() async throws {
         let cache = NSCache<AnyObject, AnyObject>()

--- a/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/NetworkingTests/NetworkingTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Networking
 
 class NetworkingTests: XCTestCase {
-    let baseURL = "http://httpbin.org"
+    let baseURL = "http://example.com"
 
     func setAuthorizationHeaderCustomValue() async throws {
         let networking = Networking(baseURL: baseURL)
@@ -37,34 +37,34 @@ class NetworkingTests: XCTestCase {
     func testURLForPath() throws {
         let networking = Networking(baseURL: baseURL)
         let url = try networking.composedURL(with: "/hello")
-        XCTAssertEqual(url.absoluteString, "http://httpbin.org/hello")
+        XCTAssertEqual(url.absoluteString, "http://example.com/hello")
     }
 
     func testURLForPathWithFullPath() throws {
         let networking = Networking()
-        let url = try networking.composedURL(with: "http://httpbin.org/hello")
-        XCTAssertEqual(url.absoluteString, "http://httpbin.org/hello")
+        let url = try networking.composedURL(with: "http://example.com/hello")
+        XCTAssertEqual(url.absoluteString, "http://example.com/hello")
     }
 
     func testDestinationURL() throws {
         let networking = Networking(baseURL: baseURL)
         let path = "/image/png"
         let destinationURL = try networking.destinationURL(for: path)
-        XCTAssertEqual(destinationURL.lastPathComponent, "http:--httpbin.org-image-png")
+        XCTAssertEqual(destinationURL.lastPathComponent, "http:--example.com-image-png")
     }
 
     func testDestinationURLWithFullPath() throws {
         let networking = Networking()
-        let path = "http://httpbin.org/image/png"
+        let path = "http://example.com/image/png"
         let destinationURL = try networking.destinationURL(for: path)
-        XCTAssertEqual(destinationURL.lastPathComponent, "http:--httpbin.org-image-png")
+        XCTAssertEqual(destinationURL.lastPathComponent, "http:--example.com-image-png")
     }
 
     func testDestinationURLWithSpecialCharactersInPath() throws {
         let networking = Networking(baseURL: baseURL)
         let path = "/h�sttur.jpg"
         let destinationURL = try networking.destinationURL(for: path)
-        XCTAssertEqual(destinationURL.lastPathComponent, "http:--httpbin.org-h%EF%BF%BDsttur.jpg")
+        XCTAssertEqual(destinationURL.lastPathComponent, "http:--example.com-h%EF%BF%BDsttur.jpg")
     }
 
     func testDestinationURLWithSpecialCharactersInCacheName() throws {
@@ -103,8 +103,8 @@ class NetworkingTests: XCTestCase {
         XCTAssertEqual(baseURL1, "https://rescuejuice.com")
         XCTAssertEqual(relativePath1, "/wp-content/uploads/2015/11/døgnvillburgere.jpg")
 
-        let (baseURL2, relativePath2) = Networking.splitBaseURLAndRelativePath(for: "http://httpbin.org/basic-auth/user/passwd")
-        XCTAssertEqual(baseURL2, "http://httpbin.org")
+        let (baseURL2, relativePath2) = Networking.splitBaseURLAndRelativePath(for: "http://example.com/basic-auth/user/passwd")
+        XCTAssertEqual(baseURL2, "http://example.com")
         XCTAssertEqual(relativePath2, "/basic-auth/user/passwd")
     }
 

--- a/Tests/NetworkingTests/NewNetworkingTests.swift
+++ b/Tests/NetworkingTests/NewNetworkingTests.swift
@@ -4,7 +4,7 @@ import CoreLocation
 @testable import Networking
 
 class NewNetworkingTests: XCTestCase {
-    let baseURL = "http://httpbin.org"
+    let baseURL = TestConfig.httpbinBaseURL
 
     func testErrorNetworkingJSON() async throws {
         let networking = Networking(baseURL: baseURL)

--- a/Tests/NetworkingTests/TestHelpers.swift
+++ b/Tests/NetworkingTests/TestHelpers.swift
@@ -2,14 +2,13 @@ import Foundation
 @testable import Networking
 
 enum TestConfig {
-    /// Base URL for httpbin-backed integration tests. Defaults to the public service;
-    /// CI overrides it with HTTPBIN_BASE_URL to point at a locally-run go-httpbin instance.
-    static let httpbinBaseURL = ProcessInfo.processInfo.environment["HTTPBIN_BASE_URL"] ?? "http://httpbin.org"
+    /// Base URL for httpbin-backed integration tests. Defaults to a local go-httpbin on :8080;
+    /// CI sets HTTPBIN_BASE_URL to the same. Run one with `docker run -p 8080:8080 mccutchen/go-httpbin`.
+    static let httpbinBaseURL = ProcessInfo.processInfo.environment["HTTPBIN_BASE_URL"] ?? "http://127.0.0.1:8080"
 }
 
-/// httpbin echoes request maps (headers/form/args/files) under a top-level key. httpbin.org
-/// uses `String` values; go-httpbin uses `[String]`. Normalize either shape to `[String: String]`
-/// so integration tests pass against both.
+/// httpbin echoes request maps (headers/form/args/files) under a top-level key, with values as
+/// either `String` or `[String]` depending on the server. Normalize both to `[String: String]`.
 func httpbinEchoedMap(_ json: [String: Any], _ key: String) -> [String: String] {
     guard let raw = json[key] as? [String: Any] else { return [:] }
     var result: [String: String] = [:]

--- a/Tests/NetworkingTests/UnauthorizedCallbackTests.swift
+++ b/Tests/NetworkingTests/UnauthorizedCallbackTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import Networking
 
 class UnauthorizedCallbackTests: XCTestCase {
-    let baseURL = "http://httpbin.org"
+    let baseURL = TestConfig.httpbinBaseURL
 
     func testCallbackWithFakedRequest() async throws {
         let networking = Networking(baseURL: baseURL)

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -49,11 +49,11 @@ Then, one verb per PR — migrate the `old*` test call sites to the new API and 
 
 2. ~~**Rename `NetworkingResponse` → `JSONResponse`.**~~ ✅ Done. Renamed the type (and `NetworkingResponse.swift` → `JSONResponse.swift`) and all ~100 references across sources, tests, and the README — symmetric with `ImageResponse`/`DataResponse`. Pure mechanical rename; suite stayed green.
 
-3. ~~**Purge `http://httpbin.org` from the test suite.**~~ ✅ Done — handled by role:
+3. ~~**Purge the public httpbin host from the test suite.**~~ ✅ Done — handled by role:
    1. **Integration fallback** — `TestConfig.httpbinBaseURL` now defaults to `"http://127.0.0.1:8080"` (matching CI's go-httpbin), so a bare local `swift test` fails fast with connection-refused instead of flaking against the public host.
    2. **Offline suites** (`GETTests`, `NewNetworkingTests`, `FakeRequestTests`, `UnauthorizedCallbackTests`) — `baseURL` now reads `TestConfig.httpbinBaseURL` (faked requests; host never contacted).
    3. **`NetworkingTests.swift`** — URL-composition / cache-filename sample data switched to `example.com` (input and expected sides together).
-   4. **README** — every `http://httpbin.org` snippet switched to `http://example.com` too, so there's zero reference left anywhere in the repo.
+   4. **README** — every public-host snippet switched to `http://example.com` too, so there's zero reference left anywhere in the repo.
    - DX: added a `Makefile` (`make test` spins up go-httpbin in Docker, runs the suite, tears it down; `make httpbin`/`httpbin-stop` for iterating) + a "Running the tests" README section, now that the default is `127.0.0.1:8080`.
 
 4. **Drop the internal `JSON` enum.** `JSON` (`JSON.swift`) is an internal parsing helper still used by file-based fakes (`FileManager.json`) and the cache path in `Networking+Private.swift`. Replace those uses with `JSONSerialization`/`Codable` directly and delete the enum (+ `JSONTests`/`JSONIntegrationTests`).

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -53,7 +53,8 @@ Then, one verb per PR — migrate the `old*` test call sites to the new API and 
    1. **Integration fallback** — `TestConfig.httpbinBaseURL` now defaults to `"http://127.0.0.1:8080"` (matching CI's go-httpbin), so a bare local `swift test` fails fast with connection-refused instead of flaking against the public host.
    2. **Offline suites** (`GETTests`, `NewNetworkingTests`, `FakeRequestTests`, `UnauthorizedCallbackTests`) — `baseURL` now reads `TestConfig.httpbinBaseURL` (faked requests; host never contacted).
    3. **`NetworkingTests.swift`** — URL-composition / cache-filename sample data switched to `example.com` (input and expected sides together).
-   - Not touched: the **README** still uses `http://httpbin.org` in its illustrative snippets — that's a separate doc call (httpbin.org is the canonical example service, and some snippets show its echoed response body), out of this test-suite-scoped item.
+   4. **README** — every `http://httpbin.org` snippet switched to `http://example.com` too, so there's zero reference left anywhere in the repo.
+   - DX: added a `Makefile` (`make test` spins up go-httpbin in Docker, runs the suite, tears it down; `make httpbin`/`httpbin-stop` for iterating) + a "Running the tests" README section, now that the default is `127.0.0.1:8080`.
 
 4. **Drop the internal `JSON` enum.** `JSON` (`JSON.swift`) is an internal parsing helper still used by file-based fakes (`FileManager.json`) and the cache path in `Networking+Private.swift`. Replace those uses with `JSONSerialization`/`Codable` directly and delete the enum (+ `JSONTests`/`JSONIntegrationTests`).
    - *Why fourth:* internal-only (no public surface), modest payoff, and best done after #1 so it's the last thing touching the result/parsing internals.

--- a/docs/api-modernization.md
+++ b/docs/api-modernization.md
@@ -49,11 +49,11 @@ Then, one verb per PR — migrate the `old*` test call sites to the new API and 
 
 2. ~~**Rename `NetworkingResponse` → `JSONResponse`.**~~ ✅ Done. Renamed the type (and `NetworkingResponse.swift` → `JSONResponse.swift`) and all ~100 references across sources, tests, and the README — symmetric with `ImageResponse`/`DataResponse`. Pure mechanical rename; suite stayed green.
 
-3. **Purge `http://httpbin.org` from the test suite.** CI is deterministic because it sets `HTTPBIN_BASE_URL` to a local go-httpbin, but the string still appears in three roles:
-   1. **Integration fallback** — `TestConfig.httpbinBaseURL` falls back to `"http://httpbin.org"` when the env var is unset, so a bare local `swift test` hits the public host, which rate-limits to HTTP 503 and flakes. These tests need a server speaking the httpbin protocol (`/get`, `/post`, `/put`, `/patch`, `/delete`, `/status/N`, `/delay/N`, `/uuid`, `/image/png`, `/basic-auth/...`, `/user-agent`).
-   2. **Offline suites** (`GETTests`, `NewNetworkingTests`, `FakeRequestTests`, `UnauthorizedCallbackTests`) — `let baseURL = "http://httpbin.org"` is an arbitrary base string for *faked* requests; never contacted or asserted.
-   3. **`NetworkingTests.swift`** — sample data coupled to URL-composition / cache-filename assertions (`composedURL` → `http://httpbin.org/hello`, `destinationURL.lastPathComponent` → `http:--httpbin.org-image-png`, `splitBaseURLAndRelativePath`). No server involved.
-   - *Why third:* low-risk quick win that makes a bare local `swift test` deterministic — pays off for every task here and for any contributor.
+3. ~~**Purge `http://httpbin.org` from the test suite.**~~ ✅ Done — handled by role:
+   1. **Integration fallback** — `TestConfig.httpbinBaseURL` now defaults to `"http://127.0.0.1:8080"` (matching CI's go-httpbin), so a bare local `swift test` fails fast with connection-refused instead of flaking against the public host.
+   2. **Offline suites** (`GETTests`, `NewNetworkingTests`, `FakeRequestTests`, `UnauthorizedCallbackTests`) — `baseURL` now reads `TestConfig.httpbinBaseURL` (faked requests; host never contacted).
+   3. **`NetworkingTests.swift`** — URL-composition / cache-filename sample data switched to `example.com` (input and expected sides together).
+   - Not touched: the **README** still uses `http://httpbin.org` in its illustrative snippets — that's a separate doc call (httpbin.org is the canonical example service, and some snippets show its echoed response body), out of this test-suite-scoped item.
 
 4. **Drop the internal `JSON` enum.** `JSON` (`JSON.swift`) is an internal parsing helper still used by file-based fakes (`FileManager.json`) and the cache path in `Networking+Private.swift`. Replace those uses with `JSONSerialization`/`Codable` directly and delete the enum (+ `JSONTests`/`JSONIntegrationTests`).
    - *Why fourth:* internal-only (no public surface), modest payoff, and best done after #1 so it's the last thing touching the result/parsing internals.


### PR DESCRIPTION
## What

Remove every `http://httpbin.org` reference from the repo, and make running the integration tests locally a one-liner now that the default points at a local go-httpbin.

### Purge `httpbin.org`
- **Integration fallback** — `TestConfig.httpbinBaseURL` now defaults to `"http://127.0.0.1:8080"` (matching CI's go-httpbin). A bare local `swift test` with no server fails fast (connection-refused) instead of flaking on the public host's 503 rate-limiting.
- **Offline / faked suites** (`GETTests`, `NewNetworkingTests`, `FakeRequestTests`, `UnauthorizedCallbackTests`) — `baseURL` now reads `TestConfig.httpbinBaseURL`; faked, so never contacted.
- **`NetworkingTests.swift`** — URL-composition / cache-filename sample data → `example.com` (input + expected sides together).
- **README** — every example snippet → `http://example.com` (including the echoed-response examples, for consistency).
- Net result: **no `httpbin.org` string remains anywhere** in sources, tests, or the README.

### Easier local testing
- New `Makefile`:
  - `make test` — start go-httpbin in Docker, run the suite, tear it down.
  - `make httpbin` / `make httpbin-stop` — leave it running while you iterate with `swift test`.
- README "Running the tests" section documenting it.

## Verification

`make test` runs green end-to-end and cleans up the container. Full suite against local go-httpbin: **142 tests, 0 failures**, warning-free.

## Next (see `docs/api-modernization.md`)

#4 drop the internal `JSON` enum; #5 iOS 18 bump + `@available` removal; #6 evaluate constrained-`T` for the verbs.
