### PR TITLE
feat: richer, categorized error model (#2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,12 @@ Async HTTP client for Apple platforms. **iOS 18+ / Swift 6** (`swift-tools 6.2`,
 - **Verbs:** `get`/`post`/`put`/`patch`/`delete` → `Result<T, NetworkingError>`. Pick `T`: any `Decodable` model, `Data`, `Void`, or `JSONResponse` (`{ statusCode, headers, body }`) when you want metadata.
 - **Typed bodies — no `Any`.** The encoding is chosen by the method, not an untyped `parameters:`/`parameterType:` pair (`Networking+HTTPRequests.swift`): `post`/`put`/`patch` take `body:` (any `Encodable` → JSON, ISO-8601 dates), `form:` (any flat `Encodable` → url-encoded), `parts:`+`fields:` (multipart), or `data:contentType:` (raw); `get`/`delete` take `query:` (a `[URLQueryItem]` for ordering/dupes, or any flat `Encodable`). `form:`/`query:` flatten an `Encodable` to `[String: String]` via `formFields` in `Networking+FormEncoding.swift` (JSON bridge + scalar re-decode so `Bool`→"true", not NSNumber "1"). Bodies flow through the typed `RequestBody` enum in `Networking+New.swift`.
 - **Downloads:** `downloadImage`/`downloadData` → `Result<T, NetworkingError>` where `T` is the payload (`Image`/`Data`) or an envelope (`ImageResponse`/`DataResponse`).
-- **Fakes (testing):** `fakeGET`/`fakePOST`/… take `response:` over any `Encodable` (encoded to JSON), a no-body overload for status-only fakes, or `fileName:` for bundled raw `Data`; `FakeRequest` holds a typed `Payload` enum. Errors are `NetworkingError`.
+- **Fakes (testing):** `fakeGET`/`fakePOST`/… take `response:` over any `Encodable` (encoded to JSON), a no-body overload for status-only fakes, or `fileName:` for bundled raw `Data`; `FakeRequest` holds a typed `Payload` enum.
+- **Errors (`NetworkingError.swift`):** categorized by where the failure happened — `invalidRequest(InvalidRequestReason)`, `transport(URLError)`, `http(HTTPError)`, `decoding(DecodingError, ResponseMetadata)`, `invalidResponse`, `cancelled`. `HTTPError` carries `statusCode`/`serverMessage`/`isClientError`/`isServerError`/`metadata`; cross-cutting `statusCode`, `responseMetadata`, and conservative `isRetryable` (transient transport + 408/429/5xx). Construction lives in `Networking+New.swift` (`handleResponse`/`handleSuccessfulResponse`/`mapThrownError`).
 
 ## Roadmap
 
-`docs/roadmap.md`. The async/`Result`/Swift-6 modernization is done, and #1 (typed request API — fully off `Any`) has landed. Next up (highest-leverage, dependency-free): a richer error model (#2), structured observability replacing `print` (#3).
+`docs/roadmap.md`. The async/`Result`/Swift-6 modernization is done; #1 (typed request API — fully off `Any`) and #2 (richer error model) have landed. Next up (highest-leverage, dependency-free): structured observability replacing `print` (#3).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 * [Making a request](#making-a-request)
   * [The basics](#the-basics)
   * [The Result type](#the-result-type)
+  * [Handling errors](#handling-errors)
   * [Typed request bodies](#typed-request-bodies)
 * [Choosing how the body is encoded](#choosing-how-the-body-is-encoded)
     * [JSON](#json)
@@ -191,12 +192,53 @@ case .success(let recipes):
     // recipes is [Recipe] — fully typed, no optionals
     print(recipes.map(\.title))
 case .failure(let error):
-    // error is a NetworkingError carrying the status code and message
+    // error is a NetworkingError — see "Handling errors" below
     print(error.localizedDescription)
 }
 ```
 
 Use `JSONResponse` as the type when you want the raw `statusCode`, `headers`, and `body` instead of a model.
+
+### Handling errors
+
+`NetworkingError` is categorized by *where* the request failed, so you can branch on the cause instead of parsing a message. Each case preserves the underlying error or response:
+
+```swift
+switch result {
+case .success(let value):
+    break
+case .failure(let error):
+    switch error {
+    case .invalidRequest(let reason):
+        // Couldn't build/encode the request — a caller-side bug. reason says which.
+        break
+    case .transport(let urlError):
+        // Never reached the server: offline, DNS, TLS, timeout. The underlying URLError is intact.
+        break
+    case .http(let httpError):
+        // A non-2xx response. httpError.statusCode, .serverMessage, .isClientError/.isServerError,
+        // and .metadata (headers + a truncated body snippet).
+        break
+    case .decoding(let decodingError, let metadata):
+        // 2xx but the body didn't match your type. The DecodingError and response metadata are preserved.
+        break
+    case .invalidResponse:
+        break
+    case .cancelled:
+        break
+    }
+}
+```
+
+Two conveniences cut across the cases:
+
+```swift
+error.statusCode      // Int? — present for .http and .decoding
+error.responseMetadata // ResponseMetadata? — status, headers, redaction-friendly body snippet
+error.isRetryable      // Bool — conservative: transient transport failures + HTTP 408/429/5xx
+```
+
+`isRetryable` is deliberately conservative: only transport timeouts/connection failures and a small set of status codes (408, 429, 500, 502, 503, 504). A 4xx (other than 408/429), a decoding failure, or an invalid request is never reported as retryable.
 
 ### Typed request bodies
 
@@ -345,7 +387,7 @@ let result: Result<JSONResponse, NetworkingError> = await networking.get("/entri
 
 **Faking with status code**:
 
-If you do not provide a status code for this fake request, the default returned one will be 200 (SUCCESS), but if you do provide a status code that is not 2XX, then **Networking** will return an NSError containing the status code and a proper error description.
+If you do not provide a status code for this fake request, the default returned one will be 200 (SUCCESS), but if you do provide a status code that is not 2xx, then **Networking** returns `.failure(.http(HTTPError))` carrying that status code (and any parsed `serverMessage`) — see [Handling errors](#handling-errors).
 
 Use the no-body overload (omit `response:`) for a status-code-only fake:
 

--- a/Sources/Networking/Networking+HTTPRequests.swift
+++ b/Sources/Networking/Networking+HTTPRequests.swift
@@ -198,7 +198,7 @@ extension Networking {
             data = try Self.requestBodyEncoder.encode(body)
         } catch {
             logger.error("Failed to encode request body: \(error.localizedDescription, privacy: .public)")
-            return .failure(.unexpectedError(statusCode: nil, message: "Failed to encode request body: \(error.localizedDescription)"))
+            return .failure(.invalidRequest(.bodyEncodingFailed(message: error.localizedDescription)))
         }
         return await handle(requestType, path: path, body: .json(data))
     }
@@ -221,7 +221,7 @@ extension Networking {
             fields = try formFields(from: form)
         } catch {
             logger.error("Failed to encode form parameters: \(error.localizedDescription, privacy: .public)")
-            return .failure(.unexpectedError(statusCode: nil, message: "Failed to encode form parameters: \(error.localizedDescription)"))
+            return .failure(.invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
         }
         return await handle(requestType, path: path, body: .formURLEncoded(fields))
     }
@@ -232,7 +232,7 @@ extension Networking {
             items = try formFields(from: query).map { URLQueryItem(name: $0.key, value: $0.value) }
         } catch {
             logger.error("Failed to encode query parameters: \(error.localizedDescription, privacy: .public)")
-            return .failure(.unexpectedError(statusCode: nil, message: "Failed to encode query parameters: \(error.localizedDescription)"))
+            return .failure(.invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
         }
         return await handle(requestType, path: path, query: items, cachingLevel: cachingLevel)
     }

--- a/Sources/Networking/Networking+New.swift
+++ b/Sources/Networking/Networking+New.swift
@@ -40,11 +40,11 @@ extension Networking {
                 let cached = try? JSONDecoder().decode(CachedResponse.self, from: cachedData),
                 let url = request.url,
                 let cachedResponse = HTTPURLResponse(url: url, statusCode: cached.statusCode, httpVersion: nil, headerFields: cached.headers) {
-                return try handleSuccessfulResponse(responseData: cached.body, path: path, httpResponse: cachedResponse)
+                return handleSuccessfulResponse(responseData: cached.body, path: path, httpResponse: cachedResponse)
             }
 
             let (responseData, response) = try await session.data(for: request)
-            let result: Result<T, NetworkingError> = try handleResponse(responseData: responseData, response: response, path: path)
+            let result: Result<T, NetworkingError> = handleResponse(responseData: responseData, response: response, path: path)
             if cachingLevel != .none, case .success = result, let httpResponse = response as? HTTPURLResponse {
                 let headers = Dictionary(uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
                     (key as? String).map { ($0, "\(value)") }
@@ -57,7 +57,7 @@ extension Networking {
             return result
 
         } catch {
-            return handleRequestError(error: error)
+            return mapThrownError(error, path: path)
         }
     }
 
@@ -95,7 +95,7 @@ extension Networking {
         } else {
             responseData = Data()
         }
-        return try handleResponse(responseData: responseData, response: response, path: path)
+        return handleResponse(responseData: responseData, response: response, path: path)
     }
 
     private func createRequest(path: String, requestType: RequestType, body: RequestBody, query: [URLQueryItem]) throws -> URLRequest {
@@ -168,7 +168,7 @@ extension Networking {
         }
     }
 
-    private func handleResponse<T: Decodable>(responseData: Data, response: URLResponse, path: String) throws -> Result<T, NetworkingError> {
+    private func handleResponse<T: Decodable>(responseData: Data, response: URLResponse, path: String) -> Result<T, NetworkingError> {
         guard let httpResponse = response as? HTTPURLResponse else {
             return .failure(.invalidResponse)
         }
@@ -177,75 +177,85 @@ extension Networking {
 
         switch statusCode.statusCodeType {
         case .informational, .successful:
-            return try handleSuccessfulResponse(responseData: responseData, path: path, httpResponse: httpResponse)
-        case .redirection:
-            return .failure(.unexpectedError(statusCode: statusCode, message: "Redirection occurred."))
-        case .clientError:
-            if (statusCode == 401 || statusCode == 403),
-               let callback = unauthorizedRequestCallback {
+            return handleSuccessfulResponse(responseData: responseData, path: path, httpResponse: httpResponse)
+        case .cancelled:
+            return .failure(.cancelled)
+        case .redirection, .clientError, .serverError, .unknown:
+            if statusCode == 401 || statusCode == 403, let callback = unauthorizedRequestCallback {
                 callback()
             }
-
-            return try handleClientError(responseData: responseData, statusCode: statusCode, path: path)
-        case .serverError:
-            return try handleServerError(responseData: responseData, statusCode: statusCode, path: path)
-        case .cancelled:
-            return .failure(.unexpectedError(statusCode: statusCode, message: "Request was cancelled."))
-        case .unknown:
-            return .failure(.unexpectedError(statusCode: statusCode, message: "An unexpected error occurred."))
+            // Parse a recognized error body into a message; keep the raw (truncated) body in metadata regardless.
+            let parsedMessage = (try? JSONDecoder().decode(ErrorResponse.self, from: responseData))?.combinedMessage
+            let serverMessage = (parsedMessage?.isEmpty == false) ? parsedMessage : nil
+            let error = HTTPError(statusCode: statusCode, metadata: responseMetadata(httpResponse, body: responseData), serverMessage: serverMessage)
+            return .failure(.http(error))
         }
     }
 
-    private func handleSuccessfulResponse<T: Decodable>(responseData: Data, path: String, httpResponse: HTTPURLResponse) throws -> Result<T, NetworkingError> {
+    private func handleSuccessfulResponse<T: Decodable>(responseData: Data, path: String, httpResponse: HTTPURLResponse) -> Result<T, NetworkingError> {
         if T.self == Data.self {
             return .success(Data() as! T)
         } else if T.self == JSONResponse.self {
             let headers = Dictionary(uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
                 (key as? String).map { ($0, AnyCodable(value)) }
             })
-            // An empty body (e.g. 204 No Content) is a success — decoding empty data would fail, so use an empty body.
-            let body = responseData.isEmpty ? [:] : try JSONDecoder().decode([String: AnyCodable].self, from: responseData)
-            let networkingJSON = JSONResponse(statusCode: httpResponse.statusCode, headers: headers, body: body)
-            return .success(networkingJSON as! T)
+            do {
+                // An empty body (e.g. 204 No Content) is a success — decoding empty data would fail, so use an empty body.
+                let body = responseData.isEmpty ? [:] : try JSONDecoder().decode([String: AnyCodable].self, from: responseData)
+                let networkingJSON = JSONResponse(statusCode: httpResponse.statusCode, headers: headers, body: body)
+                return .success(networkingJSON as! T)
+            } catch let error as DecodingError {
+                return .failure(.decoding(error, responseMetadata(httpResponse, body: responseData)))
+            } catch {
+                return .failure(.invalidResponse) // JSONDecoder only throws DecodingError; unreachable.
+            }
         } else {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .iso8601
-            let decodedResponse = try decoder.decode(T.self, from: responseData)
-            return .success(decodedResponse)
+            do {
+                return .success(try decoder.decode(T.self, from: responseData))
+            } catch let error as DecodingError {
+                logger.error("Failed to decode response: \(error.detailedMessage, privacy: .public)")
+                return .failure(.decoding(error, responseMetadata(httpResponse, body: responseData)))
+            } catch {
+                return .failure(.invalidResponse) // JSONDecoder only throws DecodingError; unreachable.
+            }
         }
     }
 
-    private func handleClientError<T: Decodable>(responseData: Data, statusCode: Int, path: String) throws -> Result<T, NetworkingError> {
-        let errorMessage = HTTPURLResponse.localizedString(forStatusCode: statusCode)
-        if let errorResponse = try? JSONDecoder().decode(ErrorResponse.self, from: responseData) {
-            return .failure(.clientError(statusCode: statusCode, message: errorResponse.combinedMessage))
-        } else {
-            return .failure(.clientError(statusCode: statusCode, message: errorMessage))
-        }
+    private func responseMetadata(_ httpResponse: HTTPURLResponse, body: Data) -> ResponseMetadata {
+        let headers = Dictionary(uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
+            (key as? String).map { ($0, "\(value)") }
+        })
+        return ResponseMetadata(statusCode: httpResponse.statusCode, headers: headers, bodySnippet: bodySnippet(from: body))
     }
 
-    private func handleServerError<T: Decodable>(responseData: Data, statusCode: Int, path: String) throws -> Result<T, NetworkingError> {
-        let errorMessage = HTTPURLResponse.localizedString(forStatusCode: statusCode)
-        var errorDetails: [String: any Sendable]? = nil
-        if let errorResponse = try? JSONDecoder().decode(ErrorResponse.self, from: responseData) {
-            errorDetails = ["error": errorResponse.error ?? "",
-                            "message": errorResponse.message ?? "",
-                            "errors": errorResponse.errors ?? [:]]
-            return .failure(.serverError(statusCode: statusCode, message: errorResponse.combinedMessage, details: errorDetails))
-        } else {
-            return .failure(.serverError(statusCode: statusCode, message: errorMessage, details: errorDetails))
-        }
+    // A bounded, log-friendly view of the body — never the whole payload.
+    private func bodySnippet(from data: Data, limit: Int = 512) -> String? {
+        guard !data.isEmpty, let string = String(data: data, encoding: .utf8) else { return nil }
+        guard string.count > limit else { return string }
+        return String(string.prefix(limit)) + "… (truncated)"
     }
 
-    private func handleRequestError<T: Decodable>(error: Error) -> Result<T, NetworkingError> {
-        if error is CancellationError || (error as? URLError)?.code == .cancelled {
+    private func mapThrownError<T: Decodable>(_ error: Error, path: String) -> Result<T, NetworkingError> {
+        if error is CancellationError {
             return .failure(.cancelled)
         }
-        if let decodingError = error as? DecodingError {
-            logger.error("Unexpected error occurred: \(decodingError.detailedMessage, privacy: .public)")
-        } else {
-            logger.error("Unexpected error occurred: \(error.localizedDescription, privacy: .public)")
+        if let urlError = error as? URLError {
+            if urlError.code == .cancelled {
+                return .failure(.cancelled)
+            }
+            if urlError.code == .badURL {
+                return .failure(.invalidRequest(.invalidURL(path)))
+            }
+            logger.error("Transport error for \(path, privacy: .public): \(urlError.localizedDescription, privacy: .public)")
+            return .failure(.transport(urlError))
         }
-        return .failure(.unexpectedError(statusCode: nil, message: "Failed to process request (error: \(error.localizedDescription))."))
+        // composedURL throws an NSError in our domain when the URL can't be built from baseURL + path.
+        if (error as NSError).domain == Networking.domain {
+            return .failure(.invalidRequest(.invalidURL(path)))
+        }
+        logger.error("Unexpected error for \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        return .failure(.transport(URLError(.unknown)))
     }
 }

--- a/Sources/Networking/Networking+Private.swift
+++ b/Sources/Networking/Networking+Private.swift
@@ -155,19 +155,19 @@ extension Networking {
     }
 
     private func downloadError(forStatusCode statusCode: Int) -> NetworkingError {
-        let message = HTTPURLResponse.localizedString(forStatusCode: statusCode)
-        switch statusCode.statusCodeType {
-        case .clientError: return .clientError(statusCode: statusCode, message: message)
-        case .serverError: return .serverError(statusCode: statusCode, message: message, details: nil)
-        default: return .unexpectedError(statusCode: statusCode, message: message)
-        }
+        // Downloads don't retain the response body/headers at this point, so the metadata is status-only.
+        let metadata = ResponseMetadata(statusCode: statusCode, headers: [:], bodySnippet: nil)
+        return .http(HTTPError(statusCode: statusCode, metadata: metadata, serverMessage: nil))
     }
 
     private func downloadError(_ error: Error) -> NetworkingError {
         if error is CancellationError || (error as? URLError)?.code == .cancelled {
             return .cancelled
         }
-        return .unexpectedError(statusCode: nil, message: "Failed to process request (error: \(error.localizedDescription)).")
+        if let urlError = error as? URLError {
+            return .transport(urlError)
+        }
+        return .transport(URLError(.unknown))
     }
 
     func requestData(_ requestType: RequestType, path: String, cachingLevel: CachingLevel, responseType: ResponseType) async throws -> (Data, HTTPURLResponse) {

--- a/Sources/Networking/NetworkingError.swift
+++ b/Sources/Networking/NetworkingError.swift
@@ -1,32 +1,132 @@
 import Foundation
 
+/// A request failure, categorized by where it happened so callers can inspect the underlying cause
+/// rather than parse a stringified catch-all.
 public enum NetworkingError: Error {
-    case invalidURL
+    /// The request couldn't be built or its body/parameters couldn't be encoded — a caller-side bug.
+    case invalidRequest(InvalidRequestReason)
+    /// The request never produced an HTTP response: offline, DNS failure, TLS failure, timeout, etc.
+    /// Carries the underlying `URLError`.
+    case transport(URLError)
+    /// An HTTP response arrived with a non-2xx status code. Carries the status, response metadata, and
+    /// any message parsed from the error body.
+    case http(HTTPError)
+    /// A response arrived but its body couldn't be decoded into the requested type. Carries the
+    /// underlying `DecodingError` and the response metadata for debugging.
+    case decoding(DecodingError, ResponseMetadata)
+    /// The response wasn't an HTTP response at all.
     case invalidResponse
-    case clientError(statusCode: Int, message: String)
-    case serverError(statusCode: Int, message: String, details: [String: any Sendable]?)
-    case unexpectedError(statusCode: Int?, message: String)
+    /// The request was cancelled.
     case cancelled
+}
+
+public extension NetworkingError {
+    /// The HTTP status code, when the failure carries one (`.http` or `.decoding`).
+    var statusCode: Int? {
+        switch self {
+        case let .http(error): return error.statusCode
+        case let .decoding(_, metadata): return metadata.statusCode
+        default: return nil
+        }
+    }
+
+    /// The response metadata, when the failure carries a response (`.http` or `.decoding`).
+    var responseMetadata: ResponseMetadata? {
+        switch self {
+        case let .http(error): return error.metadata
+        case let .decoding(_, metadata): return metadata
+        default: return nil
+        }
+    }
+
+    /// Whether retrying the request might plausibly succeed. Conservative: only transient transport
+    /// failures and a small set of HTTP status codes (408, 429, 500, 502, 503, 504) — never 4xx
+    /// (other than 408/429), decoding, invalid-request, invalid-response, or cancellation.
+    var isRetryable: Bool {
+        switch self {
+        case let .transport(error):
+            switch error.code {
+            case .timedOut, .networkConnectionLost, .cannotConnectToHost, .dnsLookupFailed:
+                return true
+            default:
+                return false
+            }
+        case let .http(error):
+            switch error.statusCode {
+            case 408, 429, 500, 502, 503, 504:
+                return true
+            default:
+                return false
+            }
+        case .invalidRequest, .decoding, .invalidResponse, .cancelled:
+            return false
+        }
+    }
+}
+
+/// Why a request couldn't be built or encoded. Carries a message rather than the typed encoding error,
+/// since these are caller-side setup bugs where the description is what's actionable.
+public enum InvalidRequestReason: Sendable, Equatable {
+    case invalidURL(String)
+    case bodyEncodingFailed(message: String)
+    case parameterEncodingFailed(message: String)
+}
+
+/// A non-2xx HTTP response, with everything needed to inspect or log it.
+public struct HTTPError: Error, Sendable {
+    public let statusCode: Int
+    public let metadata: ResponseMetadata
+    /// A human-readable message parsed from a recognized error body, when present.
+    public let serverMessage: String?
+
+    public init(statusCode: Int, metadata: ResponseMetadata, serverMessage: String?) {
+        self.statusCode = statusCode
+        self.metadata = metadata
+        self.serverMessage = serverMessage
+    }
+
+    public var isClientError: Bool { (400 ..< 500).contains(statusCode) }
+    public var isServerError: Bool { (500 ..< 600).contains(statusCode) }
+}
+
+/// Metadata about an HTTP response, retained on failures for logging and debugging.
+public struct ResponseMetadata: Sendable {
+    public let statusCode: Int
+    public let headers: [String: String]
+    /// A truncated, log-friendly snippet of the response body — not the full payload. May still contain
+    /// sensitive data, so treat it as you would any request/response contents.
+    public let bodySnippet: String?
+
+    public init(statusCode: Int, headers: [String: String], bodySnippet: String?) {
+        self.statusCode = statusCode
+        self.headers = headers
+        self.bodySnippet = bodySnippet
+    }
 }
 
 extension NetworkingError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .invalidURL:
-            return "We're sorry, but the URL for this request is invalid."
-        case .invalidResponse:
-            return "We're sorry, but we received an invalid response from the server."
-        case .clientError(let statusCode, let message):
-            return "We're sorry, but a client error occurred. Code: \(statusCode), \(message)."
-        case .serverError(let statusCode, let message, let details):
-            var detailsString = ""
-            if let details = details {
-                detailsString = details.map { "\($0.key): \($0.value)" }.joined(separator: ", ")
+        case let .invalidRequest(reason):
+            switch reason {
+            case let .invalidURL(path):
+                return "The request URL is invalid: \(path)."
+            case let .bodyEncodingFailed(message):
+                return "Failed to encode the request body: \(message)"
+            case let .parameterEncodingFailed(message):
+                return "Failed to encode the request parameters: \(message)"
             }
-            return "We're sorry, but a server error occurred. Code: \(statusCode) \(message). Additional info: \(detailsString)"
-        case .unexpectedError(let statusCode, let message):
-            let statusCodeMessage = statusCode != nil ? "Code: \(statusCode!). " : ""
-            return "We're sorry, but an unexpected error occurred. \(statusCodeMessage)\(message)"
+        case let .transport(error):
+            return "A network error occurred: \(error.localizedDescription)"
+        case let .http(error):
+            if let serverMessage = error.serverMessage, !serverMessage.isEmpty {
+                return "The server returned status \(error.statusCode): \(serverMessage)"
+            }
+            return "The server returned status \(error.statusCode) (\(HTTPURLResponse.localizedString(forStatusCode: error.statusCode)))."
+        case let .decoding(error, metadata):
+            return "Failed to decode the response (status \(metadata.statusCode)): \(error.detailedMessage)"
+        case .invalidResponse:
+            return "The server returned a response that wasn't valid HTTP."
         case .cancelled:
             return "The request was cancelled."
         }

--- a/Tests/NetworkingTests/DELETEIntegrationTests.swift
+++ b/Tests/NetworkingTests/DELETEIntegrationTests.swift
@@ -36,10 +36,10 @@ class DELETEIntegrationTests: XCTestCase {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 404)
+            XCTAssertEqual(httpError.statusCode, 404)
         }
     }
 

--- a/Tests/NetworkingTests/ErrorModelIntegrationTests.swift
+++ b/Tests/NetworkingTests/ErrorModelIntegrationTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import XCTest
+@testable import Networking
+
+final class ErrorModelIntegrationTests: XCTestCase {
+    let baseURL = TestConfig.httpbinBaseURL
+
+    // A 5xx is an HTTP error that's worth retrying; a 4xx (other than 408/429) is not.
+    func testRetryableServerErrorVsClientError() async throws {
+        let networking = Networking(baseURL: baseURL)
+
+        let serverResult: Result<Data, NetworkingError> = await networking.get("/status/503")
+        guard case let .failure(serverError) = serverResult, case .http = serverError else {
+            return XCTFail("expected an HTTP error for 503")
+        }
+        XCTAssertTrue(serverError.isRetryable, "503 should be retryable")
+        XCTAssertEqual(serverError.statusCode, 503)
+
+        let clientResult: Result<Data, NetworkingError> = await networking.get("/status/404")
+        guard case let .failure(clientError) = clientResult, case .http = clientError else {
+            return XCTFail("expected an HTTP error for 404")
+        }
+        XCTAssertFalse(clientError.isRetryable, "404 should not be retryable")
+    }
+
+    // A connection to a closed port never reaches a server: a transport failure carrying the URLError, and retryable.
+    func testTransportErrorIsRetryable() async throws {
+        let networking = Networking(baseURL: "http://127.0.0.1:1")
+        let result: Result<Data, NetworkingError> = await networking.get("/anything")
+        guard case let .failure(error) = result, case let .transport(urlError) = error else {
+            return XCTFail("expected a transport error, got \(result)")
+        }
+        XCTAssertTrue(error.isRetryable, "a connection failure should be retryable")
+        XCTAssertNotEqual(urlError.code, .cancelled)
+    }
+
+    // A 2xx whose body doesn't match the requested type surfaces as .decoding, with the DecodingError and
+    // response metadata preserved — and is not retryable.
+    func testDecodingErrorCarriesMetadata() async throws {
+        struct Mismatch: Decodable { let args: Int } // httpbin's /get returns `args` as an object, not an Int.
+        let networking = Networking(baseURL: baseURL)
+        let result: Result<Mismatch, NetworkingError> = await networking.get("/get")
+        guard case let .failure(error) = result, case let .decoding(_, metadata) = error else {
+            return XCTFail("expected a decoding error, got \(result)")
+        }
+        XCTAssertEqual(metadata.statusCode, 200)
+        XCTAssertNotNil(metadata.bodySnippet)
+        XCTAssertFalse(error.isRetryable, "decoding failures should not be retryable")
+    }
+
+    // A body that can't be JSON-encoded is a caller-side bug: .invalidRequest, never sent.
+    func testUnencodableBodyIsInvalidRequest() async throws {
+        struct Unencodable: Encodable { let value = Double.infinity } // JSONEncoder throws by default.
+        let networking = Networking(baseURL: baseURL)
+        let result: Result<Data, NetworkingError> = await networking.post("/post", body: Unencodable())
+        guard case let .failure(error) = result, case let .invalidRequest(reason) = error else {
+            return XCTFail("expected an invalid-request error, got \(result)")
+        }
+        guard case .bodyEncodingFailed = reason else {
+            return XCTFail("expected a body-encoding reason, got \(reason)")
+        }
+        XCTAssertFalse(error.isRetryable)
+    }
+}

--- a/Tests/NetworkingTests/FakeRequestTests.swift
+++ b/Tests/NetworkingTests/FakeRequestTests.swift
@@ -211,10 +211,10 @@ extension FakeRequestTests {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 401)
+            XCTAssertEqual(httpError.statusCode, 401)
         }
     }
 
@@ -228,11 +228,11 @@ extension FakeRequestTests {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, message) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 401)
-            XCTAssertTrue(message.contains("Shit went down"))
+            XCTAssertEqual(httpError.statusCode, 401)
+            XCTAssertTrue(httpError.serverMessage?.contains("Shit went down") ?? false)
         }
     }
 
@@ -322,10 +322,10 @@ extension FakeRequestTests {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 401)
+            XCTAssertEqual(httpError.statusCode, 401)
         }
     }
 
@@ -407,10 +407,10 @@ extension FakeRequestTests {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 401)
+            XCTAssertEqual(httpError.statusCode, 401)
         }
     }
 
@@ -469,10 +469,10 @@ extension FakeRequestTests {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 401)
+            XCTAssertEqual(httpError.statusCode, 401)
         }
     }
 
@@ -555,10 +555,10 @@ extension FakeRequestTests {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 401)
+            XCTAssertEqual(httpError.statusCode, 401)
         }
     }
 
@@ -636,10 +636,10 @@ extension FakeRequestTests {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 401)
+            XCTAssertEqual(httpError.statusCode, 401)
         }
     }
 

--- a/Tests/NetworkingTests/GETIntegrationTests.swift
+++ b/Tests/NetworkingTests/GETIntegrationTests.swift
@@ -48,10 +48,10 @@ class GETIntegrationTests: XCTestCase {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 404)
+            XCTAssertEqual(httpError.statusCode, 404)
         }
     }
 
@@ -62,19 +62,21 @@ class GETIntegrationTests: XCTestCase {
         let ok: Result<Data, NetworkingError> = await networking.get("/status/200")
         if case let .failure(error) = ok { XCTFail("200 should succeed, got \(error)") }
 
-        // 4xx -> clientError carrying the status code.
+        // 4xx -> .http carrying the status code, flagged as a client error.
         let clientError: Result<Data, NetworkingError> = await networking.get("/status/404")
-        guard case let .failure(.clientError(clientStatus, _)) = clientError else {
-            return XCTFail("expected a client error")
+        guard case let .failure(.http(clientHTTPError)) = clientError else {
+            return XCTFail("expected an HTTP error")
         }
-        XCTAssertEqual(clientStatus, 404)
+        XCTAssertEqual(clientHTTPError.statusCode, 404)
+        XCTAssertTrue(clientHTTPError.isClientError)
 
-        // 5xx -> serverError carrying the status code.
+        // 5xx -> .http carrying the status code, flagged as a server error.
         let serverError: Result<Data, NetworkingError> = await networking.get("/status/500")
-        guard case let .failure(.serverError(serverStatus, _, _)) = serverError else {
+        guard case let .failure(.http(serverHTTPError)) = serverError else {
             return XCTFail("expected a server error")
         }
-        XCTAssertEqual(serverStatus, 500)
+        XCTAssertEqual(serverHTTPError.statusCode, 500)
+        XCTAssertTrue(serverHTTPError.isServerError)
     }
 
     func testGETWithURLEncodedParameters() async throws {

--- a/Tests/NetworkingTests/PATCHIntegrationTests.swift
+++ b/Tests/NetworkingTests/PATCHIntegrationTests.swift
@@ -40,10 +40,10 @@ class PATCHIntegrationTests: XCTestCase {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 404)
+            XCTAssertEqual(httpError.statusCode, 404)
         }
     }
 }

--- a/Tests/NetworkingTests/POSTIntegrationTests.swift
+++ b/Tests/NetworkingTests/POSTIntegrationTests.swift
@@ -186,10 +186,10 @@ class POSTIntegrationTests: XCTestCase {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 404)
+            XCTAssertEqual(httpError.statusCode, 404)
         }
     }
 }

--- a/Tests/NetworkingTests/PUTIntegrationTests.swift
+++ b/Tests/NetworkingTests/PUTIntegrationTests.swift
@@ -40,10 +40,10 @@ class PUTIntegrationTests: XCTestCase {
         case .success:
             XCTFail()
         case let .failure(error):
-            guard case let .clientError(statusCode, _) = error else {
-                return XCTFail("expected a client error, got \(error)")
+            guard case let .http(httpError) = error else {
+                return XCTFail("expected an HTTP error, got \(error)")
             }
-            XCTAssertEqual(statusCode, 404)
+            XCTAssertEqual(httpError.statusCode, 404)
         }
     }
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -27,7 +27,11 @@ External review: the foundation is solid, but a top-tier Swift HTTP library woul
     - **Fakes:** `fake*(response:)` takes any `Encodable` (encoded to JSON), plus a no-body overload and the existing `fileName:` variant; `FakeRequest` stores a typed `Payload` enum. Internals (`handle`/`createRequest`/`httpBody`, `RequestBody`, `URLRequest` init `contentType:`, `logError`) carry no `Any`.
     - Header *values* were already `[String: String]`; a typed header-*name* vocabulary (enum of well-known keys) is a possible future ergonomics nicety, not an `Any` fix. The only remaining `Any` is the download cache substrate (`NSCache<AnyObject, AnyObject>`) and `AnyCodable` response bodies — both out of scope here.
 
-2. **Richer error model.** `NetworkingError` (`NetworkingError.swift`) collapses transport, decoding, server payload, cancellation, invalid-response, and "unexpected" into broad cases. Redesign around categories (transport / HTTP / decoding) that **preserve** the underlying `URLError`/`DecodingError`, response metadata, a redaction-safe body snippet, and retryability. Breaking — pairs with the error call sites.
+2. ~~**Richer error model.**~~ ✅ `NetworkingError` (`NetworkingError.swift`) is now categorized by where the failure happened, preserving the underlying cause:
+    - `invalidRequest(InvalidRequestReason)` (bad URL / un-encodable body or params), `transport(URLError)`, `http(HTTPError)`, `decoding(DecodingError, ResponseMetadata)`, `invalidResponse`, `cancelled`.
+    - `HTTPError` carries `statusCode`, `serverMessage` (parsed from the error body), `isClientError`/`isServerError`, and `ResponseMetadata` (headers + a truncated, log-friendly body snippet). `decoding` keeps the live `DecodingError` (Sendable in this SDK) + metadata.
+    - Cross-cutting conveniences: `statusCode`, `responseMetadata`, and a conservative `isRetryable` (transient transport failures + HTTP 408/429/5xx only).
+    - The old flat `clientError`/`serverError`/`unexpectedError`/`invalidURL` cases and the `ParameterType`-era `[String: any Sendable]` details bag are gone.
 
 3. **Structured observability — remove `print`.** `logError` writes to the console unconditionally (`Networking+Private.swift`). Replace with consumer-supplied structured logging hooks, `URLSessionTaskMetrics`, request IDs, redaction, and optional signposts. No unconditional printing.
 


### PR DESCRIPTION
Roadmap **#2 — richer error model.** Breaking.

The flat `NetworkingError` collapsed transport, decoding, server payloads, and a catch-all into broad cases, stringifying (and losing) the underlying `URLError`/`DecodingError`. This redesigns it around *where* the failure happened, preserving the cause.

## New model

```swift
public enum NetworkingError: Error {
    case invalidRequest(InvalidRequestReason)        // bad URL / un-encodable body or params (caller bug)
    case transport(URLError)                         // never reached the server: offline, DNS, TLS, timeout
    case http(HTTPError)                             // a non-2xx response arrived
    case decoding(DecodingError, ResponseMetadata)   // 2xx but the body didn't match T
    case invalidResponse
    case cancelled
}

public struct HTTPError: Error, Sendable {
    let statusCode: Int
    let metadata: ResponseMetadata        // headers + truncated body snippet
    let serverMessage: String?            // parsed from a recognized error body
    var isClientError: Bool; var isServerError: Bool
}

public struct ResponseMetadata: Sendable {
    let statusCode: Int; let headers: [String: String]; let bodySnippet: String?  // ~512 chars, never the full body
}

public extension NetworkingError {
    var statusCode: Int?                  // .http / .decoding
    var responseMetadata: ResponseMetadata?
    var isRetryable: Bool                 // conservative — see below
}
```

`isRetryable` is deliberately conservative: transient transport failures (`timedOut`, `networkConnectionLost`, `cannotConnectToHost`, `dnsLookupFailed`) + HTTP `408/429/500/502/503/504`. Nothing else — a plain 4xx, a decoding failure, or an invalid request is never retryable.

## Notable decisions

- **`Sendable` kept.** The cancellation tests wrap `Result<_, NetworkingError>` in a `Task`, which requires `NetworkingError: Sendable`. `URLError` and (in this SDK) `DecodingError` are `Sendable`, so the enum stays implicitly `Sendable` — no `@unchecked` box needed. `InvalidRequestReason` carries a *message* rather than the typed `EncodingError` to stay cleanly `Sendable` (encode failures are caller bugs where the description is what's actionable).
- **Decoding failures** are now produced inside `handleSuccessfulResponse` (where the response is in hand) as `.decoding(error, metadata)`, instead of being swallowed by the old generic catch.
- **Downloads** carry status-only metadata (the body/headers aren't retained at that point); the main request path carries full metadata.

## Tests & docs

- All `.clientError`/`.serverError` matches across the suite migrated to `.http(let httpError)` + `httpError.statusCode`/`.serverMessage`/`.isClientError`.
- New `ErrorModelIntegrationTests`: 503-retryable vs 404-not, transport error (closed port) retryable, decoding failure carries metadata, un-encodable body → `.invalidRequest`. `isRetryable` was built **red-first** (stubbed → red → implemented).
- Full suite: **141 passing**, 0 warnings.
- README gains a **Handling errors** section; roadmap #2 marked done; AGENTS.md updated.

Note: the README "Logging errors" section still describes the `print`-based output — that's roadmap #3's territory (structured observability), left untouched here.
