### PR TITLE
fix: emit observer events for pre-flight encode failures (#3 follow-up)

### DIFF
--- a/Sources/Networking/Networking+HTTPRequests.swift
+++ b/Sources/Networking/Networking+HTTPRequests.swift
@@ -197,8 +197,7 @@ extension Networking {
         do {
             data = try Self.requestBodyEncoder.encode(body)
         } catch {
-            record("✗ failed to encode request body for \(path): \(error.localizedDescription)", level: .error)
-            return .failure(.invalidRequest(.bodyEncodingFailed(message: error.localizedDescription)))
+            return emitPreflightFailure(requestType, path: path, error: .invalidRequest(.bodyEncodingFailed(message: error.localizedDescription)))
         }
         return await handle(requestType, path: path, body: .json(data))
     }
@@ -220,8 +219,7 @@ extension Networking {
         do {
             fields = try formFields(from: form)
         } catch {
-            record("✗ failed to encode form parameters for \(path): \(error.localizedDescription)", level: .error)
-            return .failure(.invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
+            return emitPreflightFailure(requestType, path: path, error: .invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
         }
         return await handle(requestType, path: path, body: .formURLEncoded(fields))
     }
@@ -231,8 +229,7 @@ extension Networking {
         do {
             items = try formFields(from: query).map { URLQueryItem(name: $0.key, value: $0.value) }
         } catch {
-            record("✗ failed to encode query parameters for \(path): \(error.localizedDescription)", level: .error)
-            return .failure(.invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
+            return emitPreflightFailure(requestType, path: path, error: .invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
         }
         return await handle(requestType, path: path, query: items, cachingLevel: cachingLevel)
     }

--- a/Sources/Networking/Networking+New.swift
+++ b/Sources/Networking/Networking+New.swift
@@ -93,24 +93,37 @@ extension Networking {
         }
 
         let duration = clock.now - startInstant
+        guard let context else { return result }
+        return complete(result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: metrics, duration: duration)
+    }
+
+    // The single completion path: logs the outcome (os.Logger + optional file) and emits `.completed`.
+    // Shared by the network path and by pre-flight failures so every request attempt reports identically.
+    private func complete<T: Decodable>(_ result: Result<T, NetworkingError>, context: RequestContext, statusCode: Int?, byteCount: Int, metrics: TransactionMetrics?, duration: Duration) -> Result<T, NetworkingError> {
         let outcome: Outcome
         switch result {
         case .success:
             outcome = .success(statusCode: statusCode ?? 0, byteCount: byteCount)
-            if let context {
-                record("← \(statusCode ?? 0) (\(byteCount) bytes) in \(duration) [\(context.id.uuidString)]", level: .info)
-            }
+            record("← \(statusCode ?? 0) (\(byteCount) bytes) in \(duration) [\(context.id.uuidString)]", level: .info)
         case let .failure(error):
             outcome = .failure(error)
-            // Out-of-the-box failure logging (os.Logger + optional file). Cancellations are intentional, so not logged as errors.
-            if !error.isCancelled, let context {
+            // Cancellations are intentional, so they're not logged as errors.
+            if !error.isCancelled {
                 logFailure(context, error: error)
             }
         }
-        if let context {
-            observer?(.completed(context, outcome: outcome, duration: duration, metrics: metrics))
-        }
+        observer?(.completed(context, outcome: outcome, duration: duration, metrics: metrics))
         return result
+    }
+
+    // A request attempt that fails before reaching the network (e.g. body/parameter encoding) still emits
+    // the same `.started`/`.completed` pair, routed through `complete`, so observers don't miss it.
+    func emitPreflightFailure<T: Decodable>(_ requestType: RequestType, path: String, error: NetworkingError) -> Result<T, NetworkingError> {
+        let requestID = UUID()
+        record("→ \(requestType.rawValue) \(path) [\(requestID.uuidString)]", level: .info)
+        let context = makeContext(id: requestID, method: requestType.rawValue, url: try? composedURL(with: path), headers: headerFields ?? [:])
+        observer?(.started(context))
+        return complete(.failure(error), context: context, statusCode: nil, byteCount: 0, metrics: nil, duration: .zero)
     }
 
     private func makeContext(id: UUID, method: String, url: URL?, headers: [String: String]) -> RequestContext {

--- a/Tests/NetworkingTests/ObservabilityIntegrationTests.swift
+++ b/Tests/NetworkingTests/ObservabilityIntegrationTests.swift
@@ -60,4 +60,25 @@ final class ObservabilityIntegrationTests: XCTestCase {
         XCTAssertEqual(context.headers["Cookie"], "<redacted>")
         XCTAssertEqual(context.headers["X-Trace"], "trace-123", "non-sensitive headers must pass through")
     }
+
+    // A request that fails to encode never reaches the network, but it's still a request attempt — it must
+    // emit the same .started/.completed pair so observers (analytics, activity indicators) don't miss it.
+    func testObserverReceivesEventsForEncodingFailure() async {
+        struct Unencodable: Encodable { let value = Double.infinity } // JSONEncoder throws by default.
+        let networking = Networking(baseURL: baseURL)
+        let events = Box<[NetworkingEvent]>([])
+        await networking.setObserver { event in events.value.append(event) }
+
+        let _: Result<Data, NetworkingError> = await networking.post("/post", body: Unencodable())
+
+        XCTAssertEqual(events.value.count, 2, "an encode failure must still emit .started and .completed; got \(events.value)")
+        guard case let .started(startContext) = events.value.first,
+              case let .completed(endContext, outcome, _, _) = events.value.last else {
+            return XCTFail("expected .started then .completed, got \(events.value)")
+        }
+        XCTAssertEqual(startContext.id, endContext.id, "both events should share a request id")
+        guard case let .failure(error) = outcome, case .invalidRequest = error else {
+            return XCTFail("expected an .invalidRequest failure outcome, got \(outcome)")
+        }
+    }
 }


### PR DESCRIPTION
Follow-up bug from #3 (caught in review).

## The bug
The three `Encodable` request paths — `post(body:)`, `post(form:)`, `get(query:)` (and put/patch/delete equivalents) — returned their **encode failure** directly from `encodeAndHandle` / `formEncodeAndHandle` / `queryEncodeAndHandle`, *before* `handle()` ran. So a body/parameter that can't encode produced **no `.started`/`.completed` events**, breaking the "one pair of events per request" contract — consumers using the observer for analytics or a network-activity indicator would silently miss `.invalidRequest(.bodyEncodingFailed/.parameterEncodingFailed)`.

## The fix
Route pre-flight failures through the **same completion path** as everything else (the reviewer's preferred option):
- Extract `complete(_:context:…)` — the single place that logs the outcome and emits `.completed` — shared by the network path and pre-flight failures.
- Add `emitPreflightFailure(_:path:error:)` — emits `.started`, then `complete(.failure(...))`. The encode helpers call it instead of returning a bare `.failure`.

Now an encode failure emits `.started` then `.completed(outcome: .failure(.invalidRequest(...)))` with a shared request id, and logs via the normal `os.Logger`/file sink — identical to any other failed request.

## Tests
Red-first: `ObservabilityIntegrationTests.testObserverReceivesEventsForEncodingFailure` (un-encodable `Double.infinity` body → asserts exactly two events, shared id, `.invalidRequest` failure outcome). Confirmed red (0 events) before the fix, green after. No server needed — encoding fails before the network.

Full suite: **147 passing**, 0 warnings. No public-API change; the README's "one `.started` and one `.completed` per request" is now actually true.
