### PR TITLE
Quality cleanups: dedup Duration.seconds, statusCodeType placement, decouple composedURL error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ model, a structured event stream, and composable request interceptors.
 - **Fakes take `Encodable`** (`fakeGET` / `fakePOST` / …), with a no-body overload and the existing
   `fileName:` variant — no more `Any`.
 - Minimum platforms raised to iOS 18 / macOS 15 / tvOS 18 / watchOS 11; Swift 6.2 language mode.
+- HTTP status-code classification moved off `Int` onto the type it describes:
+  `Networking.StatusCodeType(statusCode:)` replaces the `Int.statusCodeType` property.
+- `composedURL(with:)` now throws a typed `NetworkingError.invalidRequest(.invalidURL)` instead of an
+  untyped `NSError` when a URL can't be built.
 
 ### Removed
 
@@ -66,6 +70,8 @@ model, a structured event stream, and composable request interceptors.
   `AuthRefreshInterceptor` (pure "notify me on 401" is available on `events()`).
 - The static `Networking.deleteCachedFiles()` — replaced by the instance `clearCache()`, which clears
   both the in-memory and on-disk tiers (the static cleared only disk, leaving memory serving stale data).
+- The public `Int.statusCodeType` extension (it polluted every consumer's `Int`) — use
+  `Networking.StatusCodeType(statusCode:)`.
 
 ---
 

--- a/Sources/Networking/CacheExpiry.swift
+++ b/Sources/Networking/CacheExpiry.swift
@@ -9,7 +9,7 @@ final class CacheExpiry: @unchecked Sendable {
     private var ttlSeconds: Double
 
     init(ttl: Duration) {
-        ttlSeconds = Self.seconds(ttl)
+        ttlSeconds = ttl.seconds
     }
 
     var ttl: Duration {
@@ -19,7 +19,7 @@ final class CacheExpiry: @unchecked Sendable {
 
     func setTTL(_ ttl: Duration) {
         lock.lock(); defer { lock.unlock() }
-        ttlSeconds = Self.seconds(ttl)
+        ttlSeconds = ttl.seconds
     }
 
     // Cold = the file's last use (its modification date) is older than the TTL. A missing date (no file)
@@ -28,10 +28,5 @@ final class CacheExpiry: @unchecked Sendable {
         guard let fileDate else { return false }
         lock.lock(); defer { lock.unlock() }
         return Date().timeIntervalSince(fileDate) > ttlSeconds
-    }
-
-    static func seconds(_ duration: Duration) -> Double {
-        let (wholeSeconds, attoseconds) = duration.components
-        return Double(wholeSeconds) + Double(attoseconds) / 1e18
     }
 }

--- a/Sources/Networking/CacheStore.swift
+++ b/Sources/Networking/CacheStore.swift
@@ -192,7 +192,7 @@ final class CacheStore: @unchecked Sendable {
         defer { Self.mutationLock.unlock() }
         guard let domainURL = Self.folderURL(named: folderName) else { return }
         let now = Date()
-        let maxAge = CacheExpiry.seconds(expiry.ttl)
+        let maxAge = expiry.ttl.seconds
 
         let cursorURL = domainURL.appendingPathComponent(Self.sweepCursorFileName)
         let cursor = (try? String(contentsOf: cursorURL, encoding: .utf8)).flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } ?? 0

--- a/Sources/Networking/HTTPInterceptor.swift
+++ b/Sources/Networking/HTTPInterceptor.swift
@@ -125,13 +125,6 @@ public struct RetryInterceptor: HTTPInterceptor {
     }
 }
 
-private extension Duration {
-    var seconds: Double {
-        let (wholeSeconds, attoseconds) = components
-        return Double(wholeSeconds) + Double(attoseconds) / 1e18
-    }
-}
-
 /// Validates a successful (2xx) response beyond its status code — content-type, envelope shape — turning a
 /// "2xx but wrong" response into a typed `.validation` failure. Non-2xx responses pass through untouched so
 /// they still surface as `.http` errors. Register it outermost (before retry) to validate the final result.

--- a/Sources/Networking/Helpers.swift
+++ b/Sources/Networking/Helpers.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+extension Duration {
+    // Whole + fractional seconds as a Double, for TimeInterval / age arithmetic.
+    var seconds: Double {
+        let (wholeSeconds, attoseconds) = components
+        return Double(wholeSeconds) + Double(attoseconds) / 1e18
+    }
+}
+
 extension CharacterSet {
     static var urlQueryParametersAllowed: CharacterSet {
         // Excludes "?" and "/" per RFC 3986 §3.4.

--- a/Sources/Networking/Networking+New.swift
+++ b/Sources/Networking/Networking+New.swift
@@ -318,7 +318,7 @@ extension Networking {
 
         let statusCode = httpResponse.statusCode
 
-        switch statusCode.statusCodeType {
+        switch StatusCodeType(statusCode: statusCode) {
         case .informational, .successful:
             return handleSuccessfulResponse(responseData: responseData, path: path, httpResponse: httpResponse)
         case .cancelled:
@@ -381,7 +381,8 @@ extension Networking {
             }
             return .failure(.transport(urlError))
         }
-        // composedURL throws an NSError in our domain when the URL can't be built from baseURL + path.
+        // Fallback for the rare internal NSError still in our domain (cache path-build, param encoding);
+        // composedURL now throws a typed NetworkingError caught above.
         if (error as NSError).domain == Networking.domain {
             return .failure(.invalidRequest(.invalidURL(path)))
         }

--- a/Sources/Networking/Networking+Private.swift
+++ b/Sources/Networking/Networking+Private.swift
@@ -26,7 +26,7 @@ extension Networking {
         let url = try composedURL(with: path)
         let response = HTTPURLResponse(url: url, headerFields: fakeRequest.headerFields, statusCode: fakeRequest.statusCode)
 
-        if fakeRequest.statusCode.statusCodeType != .successful {
+        if StatusCodeType(statusCode: fakeRequest.statusCode) != .successful {
             error = NSError(statusCode: fakeRequest.statusCode)
         }
 
@@ -42,96 +42,84 @@ extension Networking {
     }
 
 
-    func handleDataRequest<T: DataDownloadable>(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) async -> Result<T, NetworkingError> {
-        let requestID = UUID()
+    // Shared download skeleton: emit `.started`, time the work, map a thrown error to a download failure,
+    // and emit `.completed`. The `work` closure does the type-specific fetch/cache/build and hands back the
+    // result plus the `statusCode`/`byteCount` that `complete` reports (kept explicit because data and image
+    // downloads set them differently — e.g. data caches before the status check, image caches success-only).
+    private func performDownload<T>(_ requestType: RequestType, path: String, _ work: () async throws -> (result: Result<T, NetworkingError>, statusCode: Int?, byteCount: Int)) async -> Result<T, NetworkingError> {
         let clock = ContinuousClock()
         let startInstant = clock.now
-        let context = RequestContext(id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
+        let context = RequestContext(id: UUID(), requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
         emit(.started(context))
 
         let result: Result<T, NetworkingError>
         var statusCode: Int?
         var byteCount = 0
         do {
-            if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
-                let (fakeResponse, _) = try handleFakeRequest(fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
-                if fakeRequest.delay > 0 {
-                    try? await Task.sleep(nanoseconds: UInt64(fakeRequest.delay * 1_000_000_000))
-                }
-                statusCode = fakeResponse.statusCode
-                if fakeResponse.statusCode.statusCodeType != .successful {
-                    result = .failure(downloadError(forStatusCode: fakeResponse.statusCode))
-                } else if case let .data(fakeData) = fakeRequest.payload {
-                    byteCount = fakeData.count
-                    result = .success(T.makeDownloadResult(data: fakeData, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse)))
-                } else {
-                    result = .failure(.invalidResponse)
-                }
-            } else if let cached = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Data {
-                let response = HTTPURLResponse(url: try composedURL(with: path), statusCode: 200)
-                statusCode = 200
-                result = .success(T.makeDownloadResult(data: cached, statusCode: 200, headers: headerFields(from: response)))
-            } else {
-                let (downloaded, networkResponse) = try await requestData(requestType, path: path, responseType: responseType)
-                try cacheOrPurgeData(data: downloaded, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
-                statusCode = networkResponse.statusCode
-                if networkResponse.statusCode.statusCodeType != .successful {
-                    result = .failure(downloadError(forStatusCode: networkResponse.statusCode))
-                } else {
-                    byteCount = downloaded.count
-                    result = .success(T.makeDownloadResult(data: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse)))
-                }
-            }
+            (result, statusCode, byteCount) = try await work()
         } catch {
             result = .failure(downloadError(error))
         }
         return complete(result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: nil, duration: clock.now - startInstant)
     }
 
-    func handleImageRequest<T: ImageDownloadable>(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) async -> Result<T, NetworkingError> {
-        let requestID = UUID()
-        let clock = ContinuousClock()
-        let startInstant = clock.now
-        let context = RequestContext(id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
-        emit(.started(context))
-
-        let result: Result<T, NetworkingError>
-        var statusCode: Int?
-        var byteCount = 0
-        do {
+    func handleDataRequest<T: DataDownloadable>(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) async -> Result<T, NetworkingError> {
+        await performDownload(requestType, path: path) {
             if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
                 let (fakeResponse, _) = try handleFakeRequest(fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
                 if fakeRequest.delay > 0 {
                     try? await Task.sleep(nanoseconds: UInt64(fakeRequest.delay * 1_000_000_000))
                 }
-                statusCode = fakeResponse.statusCode
-                if fakeResponse.statusCode.statusCodeType != .successful {
-                    result = .failure(downloadError(forStatusCode: fakeResponse.statusCode))
-                } else if case let .image(fakeImage) = fakeRequest.payload {
-                    result = .success(T.makeDownloadResult(image: fakeImage, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse)))
+                if StatusCodeType(statusCode: fakeResponse.statusCode) != .successful {
+                    return (.failure(downloadError(forStatusCode: fakeResponse.statusCode)), fakeResponse.statusCode, 0)
+                } else if case let .data(fakeData) = fakeRequest.payload {
+                    return (.success(T.makeDownloadResult(data: fakeData, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse))), fakeResponse.statusCode, fakeData.count)
                 } else {
-                    result = .failure(.invalidResponse)
+                    return (.failure(.invalidResponse), fakeResponse.statusCode, 0)
+                }
+            } else if let cached = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Data {
+                let response = HTTPURLResponse(url: try composedURL(with: path), statusCode: 200)
+                return (.success(T.makeDownloadResult(data: cached, statusCode: 200, headers: headerFields(from: response))), 200, 0)
+            } else {
+                let (downloaded, networkResponse) = try await requestData(requestType, path: path, responseType: responseType)
+                try cacheOrPurgeData(data: downloaded, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
+                if StatusCodeType(statusCode: networkResponse.statusCode) != .successful {
+                    return (.failure(downloadError(forStatusCode: networkResponse.statusCode)), networkResponse.statusCode, 0)
+                } else {
+                    return (.success(T.makeDownloadResult(data: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse))), networkResponse.statusCode, downloaded.count)
+                }
+            }
+        }
+    }
+
+    func handleImageRequest<T: ImageDownloadable>(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) async -> Result<T, NetworkingError> {
+        await performDownload(requestType, path: path) {
+            if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
+                let (fakeResponse, _) = try handleFakeRequest(fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
+                if fakeRequest.delay > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(fakeRequest.delay * 1_000_000_000))
+                }
+                if StatusCodeType(statusCode: fakeResponse.statusCode) != .successful {
+                    return (.failure(downloadError(forStatusCode: fakeResponse.statusCode)), fakeResponse.statusCode, 0)
+                } else if case let .image(fakeImage) = fakeRequest.payload {
+                    return (.success(T.makeDownloadResult(image: fakeImage, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse))), fakeResponse.statusCode, 0)
+                } else {
+                    return (.failure(.invalidResponse), fakeResponse.statusCode, 0)
                 }
             } else if let cached = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Image {
                 let response = HTTPURLResponse(url: try composedURL(with: path), statusCode: 200)
-                statusCode = 200
-                result = .success(T.makeDownloadResult(image: cached, statusCode: 200, headers: headerFields(from: response)))
+                return (.success(T.makeDownloadResult(image: cached, statusCode: 200, headers: headerFields(from: response))), 200, 0)
             } else {
                 let (data, networkResponse) = try await requestData(requestType, path: path, responseType: responseType)
-                statusCode = networkResponse.statusCode
-                if networkResponse.statusCode.statusCodeType != .successful {
-                    result = .failure(downloadError(forStatusCode: networkResponse.statusCode))
+                if StatusCodeType(statusCode: networkResponse.statusCode) != .successful {
+                    return (.failure(downloadError(forStatusCode: networkResponse.statusCode)), networkResponse.statusCode, 0)
                 } else if let downloaded = try cacheOrPurgeImage(data: data, path: path, cacheName: cacheName, cachingLevel: cachingLevel) {
-                    byteCount = data.count
-                    result = .success(T.makeDownloadResult(image: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse)))
+                    return (.success(T.makeDownloadResult(image: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse))), networkResponse.statusCode, data.count)
                 } else {
-                    result = .failure(.invalidResponse)
+                    return (.failure(.invalidResponse), networkResponse.statusCode, 0)
                 }
             }
-        } catch {
-            result = .failure(downloadError(error))
         }
-        return complete(result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: nil, duration: clock.now - startInstant)
     }
 
     private func headerFields(from response: HTTPURLResponse) -> [String: AnyCodable] {

--- a/Sources/Networking/Networking+Private.swift
+++ b/Sources/Networking/Networking+Private.swift
@@ -42,84 +42,96 @@ extension Networking {
     }
 
 
-    // Shared download skeleton: emit `.started`, time the work, map a thrown error to a download failure,
-    // and emit `.completed`. The `work` closure does the type-specific fetch/cache/build and hands back the
-    // result plus the `statusCode`/`byteCount` that `complete` reports (kept explicit because data and image
-    // downloads set them differently — e.g. data caches before the status check, image caches success-only).
-    private func performDownload<T>(_ requestType: RequestType, path: String, _ work: () async throws -> (result: Result<T, NetworkingError>, statusCode: Int?, byteCount: Int)) async -> Result<T, NetworkingError> {
+    func handleDataRequest<T: DataDownloadable>(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) async -> Result<T, NetworkingError> {
+        let requestID = UUID()
         let clock = ContinuousClock()
         let startInstant = clock.now
-        let context = RequestContext(id: UUID(), requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
+        let context = RequestContext(id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
         emit(.started(context))
 
         let result: Result<T, NetworkingError>
         var statusCode: Int?
         var byteCount = 0
         do {
-            (result, statusCode, byteCount) = try await work()
+            if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
+                let (fakeResponse, _) = try handleFakeRequest(fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
+                if fakeRequest.delay > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(fakeRequest.delay * 1_000_000_000))
+                }
+                statusCode = fakeResponse.statusCode
+                if StatusCodeType(statusCode: fakeResponse.statusCode) != .successful {
+                    result = .failure(downloadError(forStatusCode: fakeResponse.statusCode))
+                } else if case let .data(fakeData) = fakeRequest.payload {
+                    byteCount = fakeData.count
+                    result = .success(T.makeDownloadResult(data: fakeData, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse)))
+                } else {
+                    result = .failure(.invalidResponse)
+                }
+            } else if let cached = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Data {
+                let response = HTTPURLResponse(url: try composedURL(with: path), statusCode: 200)
+                statusCode = 200
+                result = .success(T.makeDownloadResult(data: cached, statusCode: 200, headers: headerFields(from: response)))
+            } else {
+                let (downloaded, networkResponse) = try await requestData(requestType, path: path, responseType: responseType)
+                try cacheOrPurgeData(data: downloaded, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
+                statusCode = networkResponse.statusCode
+                if StatusCodeType(statusCode: networkResponse.statusCode) != .successful {
+                    result = .failure(downloadError(forStatusCode: networkResponse.statusCode))
+                } else {
+                    byteCount = downloaded.count
+                    result = .success(T.makeDownloadResult(data: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse)))
+                }
+            }
         } catch {
             result = .failure(downloadError(error))
         }
         return complete(result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: nil, duration: clock.now - startInstant)
     }
 
-    func handleDataRequest<T: DataDownloadable>(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) async -> Result<T, NetworkingError> {
-        await performDownload(requestType, path: path) {
-            if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
-                let (fakeResponse, _) = try handleFakeRequest(fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
-                if fakeRequest.delay > 0 {
-                    try? await Task.sleep(nanoseconds: UInt64(fakeRequest.delay * 1_000_000_000))
-                }
-                if StatusCodeType(statusCode: fakeResponse.statusCode) != .successful {
-                    return (.failure(downloadError(forStatusCode: fakeResponse.statusCode)), fakeResponse.statusCode, 0)
-                } else if case let .data(fakeData) = fakeRequest.payload {
-                    return (.success(T.makeDownloadResult(data: fakeData, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse))), fakeResponse.statusCode, fakeData.count)
-                } else {
-                    return (.failure(.invalidResponse), fakeResponse.statusCode, 0)
-                }
-            } else if let cached = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Data {
-                let response = HTTPURLResponse(url: try composedURL(with: path), statusCode: 200)
-                return (.success(T.makeDownloadResult(data: cached, statusCode: 200, headers: headerFields(from: response))), 200, 0)
-            } else {
-                let (downloaded, networkResponse) = try await requestData(requestType, path: path, responseType: responseType)
-                try cacheOrPurgeData(data: downloaded, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
-                if StatusCodeType(statusCode: networkResponse.statusCode) != .successful {
-                    return (.failure(downloadError(forStatusCode: networkResponse.statusCode)), networkResponse.statusCode, 0)
-                } else {
-                    return (.success(T.makeDownloadResult(data: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse))), networkResponse.statusCode, downloaded.count)
-                }
-            }
-        }
-    }
-
     func handleImageRequest<T: ImageDownloadable>(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) async -> Result<T, NetworkingError> {
-        await performDownload(requestType, path: path) {
+        let requestID = UUID()
+        let clock = ContinuousClock()
+        let startInstant = clock.now
+        let context = RequestContext(id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
+        emit(.started(context))
+
+        let result: Result<T, NetworkingError>
+        var statusCode: Int?
+        var byteCount = 0
+        do {
             if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
                 let (fakeResponse, _) = try handleFakeRequest(fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
                 if fakeRequest.delay > 0 {
                     try? await Task.sleep(nanoseconds: UInt64(fakeRequest.delay * 1_000_000_000))
                 }
+                statusCode = fakeResponse.statusCode
                 if StatusCodeType(statusCode: fakeResponse.statusCode) != .successful {
-                    return (.failure(downloadError(forStatusCode: fakeResponse.statusCode)), fakeResponse.statusCode, 0)
+                    result = .failure(downloadError(forStatusCode: fakeResponse.statusCode))
                 } else if case let .image(fakeImage) = fakeRequest.payload {
-                    return (.success(T.makeDownloadResult(image: fakeImage, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse))), fakeResponse.statusCode, 0)
+                    result = .success(T.makeDownloadResult(image: fakeImage, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse)))
                 } else {
-                    return (.failure(.invalidResponse), fakeResponse.statusCode, 0)
+                    result = .failure(.invalidResponse)
                 }
             } else if let cached = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Image {
                 let response = HTTPURLResponse(url: try composedURL(with: path), statusCode: 200)
-                return (.success(T.makeDownloadResult(image: cached, statusCode: 200, headers: headerFields(from: response))), 200, 0)
+                statusCode = 200
+                result = .success(T.makeDownloadResult(image: cached, statusCode: 200, headers: headerFields(from: response)))
             } else {
                 let (data, networkResponse) = try await requestData(requestType, path: path, responseType: responseType)
+                statusCode = networkResponse.statusCode
                 if StatusCodeType(statusCode: networkResponse.statusCode) != .successful {
-                    return (.failure(downloadError(forStatusCode: networkResponse.statusCode)), networkResponse.statusCode, 0)
+                    result = .failure(downloadError(forStatusCode: networkResponse.statusCode))
                 } else if let downloaded = try cacheOrPurgeImage(data: data, path: path, cacheName: cacheName, cachingLevel: cachingLevel) {
-                    return (.success(T.makeDownloadResult(image: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse))), networkResponse.statusCode, data.count)
+                    byteCount = data.count
+                    result = .success(T.makeDownloadResult(image: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse)))
                 } else {
-                    return (.failure(.invalidResponse), networkResponse.statusCode, 0)
+                    result = .failure(.invalidResponse)
                 }
             }
+        } catch {
+            result = .failure(downloadError(error))
         }
+        return complete(result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: nil, duration: clock.now - startInstant)
     }
 
     private func headerFields(from response: HTTPURLResponse) -> [String: AnyCodable] {

--- a/Sources/Networking/Networking.swift
+++ b/Sources/Networking/Networking.swift
@@ -1,24 +1,24 @@
 import Foundation
 import os.log
 
-public extension Int {
-
-    var statusCodeType: Networking.StatusCodeType {
-        switch self {
+public extension Networking.StatusCodeType {
+    /// Classifies an HTTP status code (with `URLError.cancelled` mapped to `.cancelled`).
+    init(statusCode: Int) {
+        switch statusCode {
         case URLError.cancelled.rawValue:
-            return .cancelled
+            self = .cancelled
         case 100 ..< 200:
-            return .informational
+            self = .informational
         case 200 ..< 300:
-            return .successful
+            self = .successful
         case 300 ..< 400:
-            return .redirection
+            self = .redirection
         case 400 ..< 500:
-            return .clientError
+            self = .clientError
         case 500 ..< 600:
-            return .serverError
+            self = .serverError
         default:
-            return .unknown
+            self = .unknown
         }
     }
 }
@@ -249,7 +249,7 @@ public actor Networking {
     nonisolated public func composedURL(with path: String) throws -> URL {
         let encodedPath = path.encodeUTF8() ?? path
         guard let url = URL(string: baseURL + encodedPath) else {
-            throw NSError(domain: Networking.domain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Couldn't create a url using baseURL: \(baseURL) and encodedPath: \(encodedPath)"])
+            throw NetworkingError.invalidRequest(.invalidURL(path))
         }
         return url
     }

--- a/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/NetworkingTests/NetworkingTests.swift
@@ -101,19 +101,20 @@ class NetworkingTests: XCTestCase {
     }
 
     func testStatusCodeType() {
-        XCTAssertEqual((URLError.cancelled.rawValue).statusCodeType, Networking.StatusCodeType.cancelled)
-        XCTAssertEqual(99.statusCodeType, Networking.StatusCodeType.unknown)
-        XCTAssertEqual(100.statusCodeType, Networking.StatusCodeType.informational)
-        XCTAssertEqual(199.statusCodeType, Networking.StatusCodeType.informational)
-        XCTAssertEqual(200.statusCodeType, Networking.StatusCodeType.successful)
-        XCTAssertEqual(299.statusCodeType, Networking.StatusCodeType.successful)
-        XCTAssertEqual(300.statusCodeType, Networking.StatusCodeType.redirection)
-        XCTAssertEqual(399.statusCodeType, Networking.StatusCodeType.redirection)
-        XCTAssertEqual(400.statusCodeType, Networking.StatusCodeType.clientError)
-        XCTAssertEqual(499.statusCodeType, Networking.StatusCodeType.clientError)
-        XCTAssertEqual(500.statusCodeType, Networking.StatusCodeType.serverError)
-        XCTAssertEqual(599.statusCodeType, Networking.StatusCodeType.serverError)
-        XCTAssertEqual(600.statusCodeType, Networking.StatusCodeType.unknown)
+        typealias StatusCodeType = Networking.StatusCodeType
+        XCTAssertEqual(StatusCodeType(statusCode: URLError.cancelled.rawValue), .cancelled)
+        XCTAssertEqual(StatusCodeType(statusCode: 99), .unknown)
+        XCTAssertEqual(StatusCodeType(statusCode: 100), .informational)
+        XCTAssertEqual(StatusCodeType(statusCode: 199), .informational)
+        XCTAssertEqual(StatusCodeType(statusCode: 200), .successful)
+        XCTAssertEqual(StatusCodeType(statusCode: 299), .successful)
+        XCTAssertEqual(StatusCodeType(statusCode: 300), .redirection)
+        XCTAssertEqual(StatusCodeType(statusCode: 399), .redirection)
+        XCTAssertEqual(StatusCodeType(statusCode: 400), .clientError)
+        XCTAssertEqual(StatusCodeType(statusCode: 499), .clientError)
+        XCTAssertEqual(StatusCodeType(statusCode: 500), .serverError)
+        XCTAssertEqual(StatusCodeType(statusCode: 599), .serverError)
+        XCTAssertEqual(StatusCodeType(statusCode: 600), .unknown)
     }
 
     func testSplitBaseURLAndRelativePath() throws {


### PR DESCRIPTION
Three of the four "review leftovers" from the cache-fixes review, in their own PR. Behavior-preserving — full suite (180) green, build warning-free.

### 1. `Duration → seconds` deduplicated
One `extension Duration { var seconds }` in `Helpers.swift`. Dropped the duplicate `CacheExpiry.seconds(_:)` static and the private copy in `HTTPInterceptor.swift`; `CacheExpiry`/`CacheStore`/`RetryInterceptor` all share it.

### 2. `statusCodeType` moved off the global `Int` namespace (breaking; v8)
`public extension Int { var statusCodeType }` polluted every consumer's `Int`. Replaced with `Networking.StatusCodeType(statusCode:)` — classification lives on the type it describes. Call sites + test updated; CHANGELOG noted under Changed/Removed.

### 3. `composedURL`/`mapThrownError` decoupled
`composedURL` threw an `NSError` that `mapThrownError` recognized by **domain string**. It now throws a typed `NetworkingError.invalidRequest(.invalidURL)`, caught by the existing `as? NetworkingError` branch. The domain-string check remains only as a fallback for the rare other internal `NSError`s, with an accurate comment.

### Dropped: #4 (download-handler dedup)
Attempted to extract the shared skeleton of `handleDataRequest`/`handleImageRequest` into a `performDownload` wrapper, but passing the `async` work-closure (capturing `cachingLevel`/`self`) into an awaited call trips **Swift 6.2's region isolation** (`sending … risks data races`) — even though 6.3 accepts it. It was the least-valuable of the four (the two handlers differ in real ways: data caches before the status check, image success-only), so I reverted it rather than contort around the isolation checker. The two handlers stay as-is.

## Tests
180 green, warning-free. Behavior-preserving refactors guarded by the existing suite; the one breaking change (#2) is exercised by the updated `testStatusCodeType`.