### PR TITLE
ci: adopt swift-format + warnings/doc-link gates

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Formats staged Swift files with swift-format before each commit.
+# Enable once per clone: ./scripts/setup.sh (or git config core.hooksPath .githooks)
+set -e
+
+# NUL-delimited so paths with spaces survive. ACM excludes deletions.
+files=$(git diff --cached --name-only --diff-filter=ACM -z -- '*.swift' | tr '\0' '\n')
+[ -z "$files" ] && exit 0
+
+if ! command -v swift >/dev/null 2>&1; then
+    echo "pre-commit: swift toolchain not found; skipping swift-format." >&2
+    exit 0
+fi
+
+echo "$files" | while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    # A file with unstaged changes is partially staged; formatting in place and
+    # re-adding would pull the unstaged hunks into the commit. Skip it — CI's
+    # format check is the backstop for anything the hook can't safely touch.
+    if git diff --quiet -- "$f"; then
+        swift format --in-place "$f"
+        git add -- "$f"
+    else
+        echo "pre-commit: '$f' is partially staged; skipping format (run swift format manually)." >&2
+    fi
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,19 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
 
 jobs:
+  swift-format-check:
+    name: swift-format check
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check formatting
+        run: |
+          swift format --in-place --recursive Sources Tests
+          if ! git diff --exit-code; then
+            echo "::error::Code is not formatted. Run: swift format --in-place --recursive Sources Tests (and commit)."
+            exit 1
+          fi
+
   build-and-test:
     name: macOS Swift Build & Test
     runs-on: macos-15
@@ -40,3 +53,27 @@ jobs:
         env:
           HTTPBIN_BASE_URL: http://127.0.0.1:8080
         run: swift test -v
+
+  warnings:
+    name: Warnings gate
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+      # No SPM cache on purpose: a fresh build recompiles everything so warnings are
+      # actually re-emitted (an incremental build would skip unchanged files).
+      - name: Build and fail on first-party warnings
+        run: |
+          set -o pipefail
+          swift build --build-tests 2>&1 | tee build.log
+          if grep -E "warning:" build.log | grep -vE "\.build/(checkouts|artifacts)"; then
+            echo "::error::Build emitted warnings in first-party code. Fix them (the lines above)."
+            exit 1
+          fi
+
+  doc-links:
+    name: Doc link check
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check relative markdown links resolve
+        run: python3 scripts/check-doc-links.py

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "lineLength": 120,
+  "indentation": {
+    "spaces": 4
+  },
+  "maximumBlankLines": 1,
+  "respectsExistingLineBreaks": true,
+  "lineBreakBeforeEachArgument": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,11 @@ what's specific to this repo. Release history and the v8 (major) notes live in `
 - `swift build` — library only; CI also fails on any first-party `warning:`.
 - Integration tests need go-httpbin (`TestConfig.httpbinBaseURL`, default `http://127.0.0.1:8080`). Without it
   they fail fast (connection refused) — intended, not a flake. The offline / `fake*` suites need no server.
+- Formatting: `.swift-format` (120 cols, 4-space). Run `./scripts/setup.sh` once per clone to enable the
+  `.githooks/pre-commit` hook (formats staged Swift files); CI's format check is the backstop.
 - CI: `macos-15` / Xcode 26.3 / Swift 6.2.x (stricter region-isolation than local 6.3 — CI is the gate).
+  Jobs: swift-format check, build & test (go-httpbin), a warnings gate, and a dead-doc-link check
+  (`scripts/check-doc-links.py`).
 
 ## Source map
 

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ In your `Package.swift`:
 
 …and add `"Networking"` to your target's dependencies. In Xcode, use **File ▸ Add Package Dependencies…** and enter `https://github.com/3lvis/Networking.git`.
 
-> **Upgrading from 7.x?** 8.0.0 is a major, breaking release (async/`await` + `Result`, Swift 6, typed request bodies, a categorized error model, an event stream, and request interceptors). See [`CHANGELOG.md`](CHANGELOG.md) for the full migration.
+> **Upgrading from 7.x?** 8.0.0 is a major, breaking release (async/`await` + `Result`, Swift 6, typed request bodies, a categorized error model, an event stream, and request interceptors). See the [release notes](https://github.com/3lvis/Networking/releases) for the full migration.
 
 ## Running the tests
 

--- a/Sources/Networking/CacheExpiry.swift
+++ b/Sources/Networking/CacheExpiry.swift
@@ -13,12 +13,14 @@ final class CacheExpiry: @unchecked Sendable {
     }
 
     var ttl: Duration {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         return .seconds(ttlSeconds)
     }
 
     func setTTL(_ ttl: Duration) {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         ttlSeconds = ttl.seconds
     }
 
@@ -26,7 +28,8 @@ final class CacheExpiry: @unchecked Sendable {
     // is treated as not-expired so a present-but-unreadable entry isn't dropped spuriously.
     func isExpired(fileDate: Date?) -> Bool {
         guard let fileDate else { return false }
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         return Date().timeIntervalSince(fileDate) > ttlSeconds
     }
 }

--- a/Sources/Networking/CacheStore.swift
+++ b/Sources/Networking/CacheStore.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CryptoKit
+import Foundation
 
 // Owns both cache tiers: the in-memory `NSCache` (warm, pressure-evicted by iOS) over the on-disk shard
 // layout (cold, durable). A non-actor, synchronous type so the nonisolated cache reads
@@ -33,8 +33,11 @@ final class CacheStore: @unchecked Sendable {
         let finalPath = "\(folderPath)/\(component)"
 
         guard let url = URL(string: finalPath),
-              let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
-            throw NSError(domain: folderName, code: 9999, userInfo: [NSLocalizedDescriptionKey: "Couldn't build a cache URL for: \(finalPath)"])
+            let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        else {
+            throw NSError(
+                domain: folderName, code: 9999,
+                userInfo: [NSLocalizedDescriptionKey: "Couldn't build a cache URL for: \(finalPath)"])
         }
 
         let folderURL = cachesURL.appendingPathComponent(URL(string: folderPath)!.absoluteString)
@@ -87,7 +90,8 @@ final class CacheStore: @unchecked Sendable {
             if let object = memory.object(forKey: key as AnyObject) {
                 return object
             } else if FileManager.default.exists(at: destinationURL) {
-                let fileDate = try? destinationURL.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+                let fileDate = try? destinationURL.resourceValues(forKeys: [.contentModificationDateKey])
+                    .contentModificationDate
                 if expiry.isExpired(fileDate: fileDate) {
                     try FileManager.default.remove(at: destinationURL)
                     return nil
@@ -102,7 +106,8 @@ final class CacheStore: @unchecked Sendable {
                     memory.setObject(returnedObject as AnyObject, forKey: key as AnyObject)
                     // Re-warm: bump the file's mtime so an entry in active use never expires. Only happens
                     // on a memory miss, so it's ~once per entry per launch — no explicit debounce needed.
-                    try? FileManager.default.setAttributes([.modificationDate: Date()], ofItemAtPath: destinationURL.path)
+                    try? FileManager.default.setAttributes(
+                        [.modificationDate: Date()], ofItemAtPath: destinationURL.path)
                 }
 
                 return returnedObject
@@ -180,7 +185,9 @@ final class CacheStore: @unchecked Sendable {
     }
 
     private static func folderURL(named folderName: String) -> URL? {
-        guard let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else { return nil }
+        guard let cachesURL = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return nil
+        }
         return cachesURL.appendingPathComponent(URL(string: folderName)!.absoluteString)
     }
 
@@ -195,12 +202,20 @@ final class CacheStore: @unchecked Sendable {
         let maxAge = expiry.ttl.seconds
 
         let cursorURL = domainURL.appendingPathComponent(Self.sweepCursorFileName)
-        let cursor = (try? String(contentsOf: cursorURL, encoding: .utf8)).flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) } ?? 0
+        let cursor =
+            (try? String(contentsOf: cursorURL, encoding: .utf8)).flatMap {
+                Int($0.trimmingCharacters(in: .whitespacesAndNewlines))
+            } ?? 0
         let shardURL = domainURL.appendingPathComponent(String(cursor % Self.shardCount, radix: 16))
 
-        if let files = try? FileManager.default.contentsOfDirectory(at: shardURL, includingPropertiesForKeys: [.contentModificationDateKey], options: []) {
+        if let files = try? FileManager.default.contentsOfDirectory(
+            at: shardURL, includingPropertiesForKeys: [.contentModificationDateKey], options: [])
+        {
             for file in files {
-                guard let modified = try? file.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate else { continue }
+                guard
+                    let modified = try? file.resourceValues(forKeys: [.contentModificationDateKey])
+                        .contentModificationDate
+                else { continue }
                 if now.timeIntervalSince(modified) > maxAge {
                     try? FileManager.default.removeItem(at: file)
                 }
@@ -209,7 +224,9 @@ final class CacheStore: @unchecked Sendable {
 
         // Pre-sharding versions wrote files directly under the domain root; clear those strays (the cursor
         // file and the shard subdirectories stay).
-        if let rootEntries = try? FileManager.default.contentsOfDirectory(at: domainURL, includingPropertiesForKeys: [.isRegularFileKey], options: []) {
+        if let rootEntries = try? FileManager.default.contentsOfDirectory(
+            at: domainURL, includingPropertiesForKeys: [.isRegularFileKey], options: [])
+        {
             for entry in rootEntries where entry.lastPathComponent != Self.sweepCursorFileName {
                 if (try? entry.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true {
                     try? FileManager.default.removeItem(at: entry)

--- a/Sources/Networking/DownloadResponse.swift
+++ b/Sources/Networking/DownloadResponse.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 #if os(macOS)
     import AppKit.NSImage
 #else
@@ -38,7 +39,8 @@ public struct ImageResponse: ImageDownloadable, @unchecked Sendable {
     public let headers: [String: AnyCodable]
     public let image: Image
 
-    public static func makeDownloadResult(image: Image, statusCode: Int, headers: [String: AnyCodable]) -> ImageResponse {
+    public static func makeDownloadResult(image: Image, statusCode: Int, headers: [String: AnyCodable]) -> ImageResponse
+    {
         ImageResponse(statusCode: statusCode, headers: headers, image: image)
     }
 }

--- a/Sources/Networking/FakeRequest.swift
+++ b/Sources/Networking/FakeRequest.swift
@@ -15,7 +15,10 @@ struct FakeRequest {
     let statusCode: Int
     let delay: Double
 
-    init(payload: Payload, responseType: Networking.ResponseType, headerFields: [String : String]?, statusCode: Int, delay: Double) {
+    init(
+        payload: Payload, responseType: Networking.ResponseType, headerFields: [String: String]?, statusCode: Int,
+        delay: Double
+    ) {
         self.payload = payload
         self.responseType = responseType
         self.headerFields = headerFields
@@ -23,7 +26,10 @@ struct FakeRequest {
         self.delay = delay
     }
 
-    static func find(ofType type: Networking.RequestType, forPath path: String, in collection: [Networking.RequestType: [String: FakeRequest]]) throws -> FakeRequest? {
+    static func find(
+        ofType type: Networking.RequestType, forPath path: String,
+        in collection: [Networking.RequestType: [String: FakeRequest]]
+    ) throws -> FakeRequest? {
         guard let requests = collection[type] else { return nil }
         guard path.count > 0 else { return nil }
 
@@ -60,15 +66,19 @@ struct FakeRequest {
                 }
                 guard replacedPath == path else { continue }
                 // Substitute the captured path values into the JSON body string (e.g. "{userID}" -> "10").
-                guard case let .data(data) = fakeRequest.payload,
-                      var responseString = String(data: data, encoding: .utf8) else { continue }
+                guard case .data(let data) = fakeRequest.payload,
+                    var responseString = String(data: data, encoding: .utf8)
+                else { continue }
 
                 for (key, value) in replacedValues {
                     responseString = responseString.replacingOccurrences(of: key, with: value)
                 }
 
                 guard let stringData = responseString.data(using: .utf8) else { continue }
-                return FakeRequest(payload: .data(stringData), responseType: fakeRequest.responseType, headerFields: fakeRequest.headerFields, statusCode: fakeRequest.statusCode, delay: fakeRequest.delay)
+                return FakeRequest(
+                    payload: .data(stringData), responseType: fakeRequest.responseType,
+                    headerFields: fakeRequest.headerFields, statusCode: fakeRequest.statusCode, delay: fakeRequest.delay
+                )
             }
         }
 

--- a/Sources/Networking/HTTPInterceptor.swift
+++ b/Sources/Networking/HTTPInterceptor.swift
@@ -91,11 +91,14 @@ public struct RetryInterceptor: HTTPInterceptor {
                 let exchange = try await next(request)
                 let shouldRetry = methodAllowsRetry && retryableStatusCodes.contains(exchange.response.statusCode)
                 guard shouldRetry, attempt < maxAttempts else { return exchange }
-                let delay = Self.retryAfterDelay(from: exchange.response).map { Swift.min($0, maxDelay) }
+                let delay =
+                    Self.retryAfterDelay(from: exchange.response).map { Swift.min($0, maxDelay) }
                     ?? backoffDelay(forAttempt: attempt)
                 try await Task.sleep(for: delay)
                 attempt += 1
-            } catch let error as URLError where attempt < maxAttempts && methodAllowsRetry && NetworkingError.isRetryableTransport(error) {
+            } catch let error as URLError
+                where attempt < maxAttempts && methodAllowsRetry && NetworkingError.isRetryableTransport(error)
+            {
                 try await Task.sleep(for: backoffDelay(forAttempt: attempt))
                 attempt += 1
             }
@@ -112,7 +115,8 @@ public struct RetryInterceptor: HTTPInterceptor {
     // Retry-After is either a count of seconds or an HTTP-date (RFC 9110).
     static func retryAfterDelay(from response: HTTPURLResponse) -> Duration? {
         guard let value = response.value(forHTTPHeaderField: "Retry-After")?.trimmingCharacters(in: .whitespaces),
-              !value.isEmpty else { return nil }
+            !value.isEmpty
+        else { return nil }
         if let seconds = Int(value) {
             return .seconds(max(0, seconds))
         }
@@ -149,8 +153,9 @@ public struct ResponseValidatorInterceptor: HTTPInterceptor {
         switch validate(exchange) {
         case .valid:
             return exchange
-        case let .invalid(reason):
-            throw NetworkingError.validation(reason: reason, ResponseMetadata(response: exchange.response, body: exchange.data))
+        case .invalid(let reason):
+            throw NetworkingError.validation(
+                reason: reason, ResponseMetadata(response: exchange.response, body: exchange.data))
         }
     }
 }

--- a/Sources/Networking/Helpers.swift
+++ b/Sources/Networking/Helpers.swift
@@ -20,15 +20,19 @@ extension CharacterSet {
     }
 }
 
-public extension Dictionary where Key: ExpressibleByStringLiteral {
+extension Dictionary where Key: ExpressibleByStringLiteral {
 
-    func urlEncodedString() throws -> String {
+    public func urlEncodedString() throws -> String {
 
         let pairs = try reduce([]) { current, keyValuePair -> [String] in
-            if let encodedValue = "\(keyValuePair.value)".addingPercentEncoding(withAllowedCharacters: .urlQueryParametersAllowed) {
+            if let encodedValue = "\(keyValuePair.value)".addingPercentEncoding(
+                withAllowedCharacters: .urlQueryParametersAllowed)
+            {
                 return current + ["\(keyValuePair.key)=\(encodedValue)"]
             } else {
-                throw NSError(domain: Networking.domain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Couldn't encode \(keyValuePair.value)"])
+                throw NSError(
+                    domain: Networking.domain, code: 0,
+                    userInfo: [NSLocalizedDescriptionKey: "Couldn't encode \(keyValuePair.value)"])
             }
         }
 
@@ -68,7 +72,11 @@ extension FileManager {
 }
 
 extension URLRequest {
-    init(url: URL, requestType: Networking.RequestType, contentType: String?, responseType: Networking.ResponseType, authorizationHeaderValue: String?, token: String?, authorizationHeaderKey: String, headerFields: [String: String]?) {
+    init(
+        url: URL, requestType: Networking.RequestType, contentType: String?, responseType: Networking.ResponseType,
+        authorizationHeaderValue: String?, token: String?, authorizationHeaderKey: String,
+        headerFields: [String: String]?
+    ) {
         self = URLRequest(url: url)
         httpMethod = requestType.rawValue
 
@@ -95,13 +103,15 @@ extension URLRequest {
 }
 
 extension HTTPURLResponse {
-    convenience init(url: URL, headerFields: [String : String]? = nil, statusCode: Int) {
+    convenience init(url: URL, headerFields: [String: String]? = nil, statusCode: Int) {
         self.init(url: url, statusCode: statusCode, httpVersion: nil, headerFields: headerFields)!
     }
 }
 
 extension NSError {
     convenience init(statusCode: Int) {
-        self.init(domain: Networking.domain, code: statusCode, userInfo: [NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: statusCode)])
+        self.init(
+            domain: Networking.domain, code: statusCode,
+            userInfo: [NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: statusCode)])
     }
 }

--- a/Sources/Networking/Image.swift
+++ b/Sources/Networking/Image.swift
@@ -16,7 +16,7 @@ extension Image {
             return UIImage(named: name, in: bundle, compatibleWith: nil)!
         #endif
     }
- 
+
     #if os(macOS)
         func data(_ type: NSBitmapImageRep.FileType) -> Data? {
             let imageData = tiffRepresentation!
@@ -27,9 +27,9 @@ extension Image {
     #endif
 
     #if os(macOS)
-    func pngData() -> Data? {
-        return data(.png)
-    }
+        func pngData() -> Data? {
+            return data(.png)
+        }
     #endif
 
     func jpgData() -> Data? {

--- a/Sources/Networking/JSONResponse.swift
+++ b/Sources/Networking/JSONResponse.swift
@@ -33,7 +33,8 @@ public struct AnyCodable: Decodable, @unchecked Sendable {
         } else if let value = try? container.decode([AnyCodable].self) {
             self.value = value
         } else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "The container contains nothing serializable")
+            throw DecodingError.dataCorruptedError(
+                in: container, debugDescription: "The container contains nothing serializable")
         }
     }
 

--- a/Sources/Networking/Networking+FormEncoding.swift
+++ b/Sources/Networking/Networking+FormEncoding.swift
@@ -35,16 +35,20 @@ private enum FormScalar: Decodable {
         } else if let string = try? container.decode(String.self) {
             self = .string(string)
         } else {
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "form/query values must be String, Int, Double, or Bool — nested objects and arrays aren't supported")
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription:
+                    "form/query values must be String, Int, Double, or Bool — nested objects and arrays aren't supported"
+            )
         }
     }
 
     var stringValue: String {
         switch self {
-        case let .string(value): return value
-        case let .int(value): return String(value)
-        case let .double(value): return String(value)
-        case let .bool(value): return String(value)
+        case .string(let value): return value
+        case .int(let value): return String(value)
+        case .double(let value): return String(value)
+        case .bool(let value): return String(value)
         }
     }
 }

--- a/Sources/Networking/Networking+HTTPRequests.swift
+++ b/Sources/Networking/Networking+HTTPRequests.swift
@@ -1,177 +1,202 @@
 import Foundation
 
-public extension Networking {
+extension Networking {
 
     // MARK: GET
 
-    func get<T: Decodable>(_ path: String, query: [URLQueryItem]? = nil, cachingLevel: CachingLevel = .none) async -> Result<T, NetworkingError> {
+    public func get<T: Decodable>(_ path: String, query: [URLQueryItem]? = nil, cachingLevel: CachingLevel = .none)
+        async -> Result<T, NetworkingError>
+    {
         return await handle(.get, path: path, query: query ?? [], cachingLevel: cachingLevel)
     }
 
-    func get<Q: Encodable, T: Decodable>(_ path: String, query: Q, cachingLevel: CachingLevel = .none) async -> Result<T, NetworkingError> {
+    public func get<Q: Encodable, T: Decodable>(_ path: String, query: Q, cachingLevel: CachingLevel = .none) async
+        -> Result<T, NetworkingError>
+    {
         return await queryEncodeAndHandle(.get, path: path, query: query, cachingLevel: cachingLevel)
     }
 
     // MARK: POST
 
-    func post<T: Decodable>(_ path: String) async -> Result<T, NetworkingError> {
+    public func post<T: Decodable>(_ path: String) async -> Result<T, NetworkingError> {
         return await handle(.post, path: path)
     }
 
-    func post(_ path: String) async -> Result<Void, NetworkingError> {
+    public func post(_ path: String) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await handle(.post, path: path)
         return result.map { _ in () }
     }
 
     /// JSON body, ISO-8601 dates.
-    func post<B: Encodable, T: Decodable>(_ path: String, body: B) async -> Result<T, NetworkingError> {
+    public func post<B: Encodable, T: Decodable>(_ path: String, body: B) async -> Result<T, NetworkingError> {
         return await encodeAndHandle(.post, path: path, body: body)
     }
 
-    func post<B: Encodable>(_ path: String, body: B) async -> Result<Void, NetworkingError> {
+    public func post<B: Encodable>(_ path: String, body: B) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await encodeAndHandle(.post, path: path, body: body)
         return result.map { _ in () }
     }
 
     /// `application/x-www-form-urlencoded` body, built from a flat `Encodable`.
-    func post<F: Encodable, T: Decodable>(_ path: String, form: F) async -> Result<T, NetworkingError> {
+    public func post<F: Encodable, T: Decodable>(_ path: String, form: F) async -> Result<T, NetworkingError> {
         return await formEncodeAndHandle(.post, path: path, form: form)
     }
 
-    func post<F: Encodable>(_ path: String, form: F) async -> Result<Void, NetworkingError> {
+    public func post<F: Encodable>(_ path: String, form: F) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await formEncodeAndHandle(.post, path: path, form: form)
         return result.map { _ in () }
     }
 
-    func post<T: Decodable>(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async -> Result<T, NetworkingError> {
+    public func post<T: Decodable>(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async
+        -> Result<T, NetworkingError>
+    {
         return await handle(.post, path: path, body: .multipart(fields: fields, parts: parts))
     }
 
-    func post(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await handle(.post, path: path, body: .multipart(fields: fields, parts: parts))
+    public func post(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async -> Result<
+        Void, NetworkingError
+    > {
+        let result: Result<Data, NetworkingError> = await handle(
+            .post, path: path, body: .multipart(fields: fields, parts: parts))
         return result.map { _ in () }
     }
 
-    func post<T: Decodable>(_ path: String, data: Data, contentType: String) async -> Result<T, NetworkingError> {
+    public func post<T: Decodable>(_ path: String, data: Data, contentType: String) async -> Result<T, NetworkingError>
+    {
         return await handle(.post, path: path, body: .raw(data, contentType: contentType))
     }
 
-    func post(_ path: String, data: Data, contentType: String) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await handle(.post, path: path, body: .raw(data, contentType: contentType))
+    public func post(_ path: String, data: Data, contentType: String) async -> Result<Void, NetworkingError> {
+        let result: Result<Data, NetworkingError> = await handle(
+            .post, path: path, body: .raw(data, contentType: contentType))
         return result.map { _ in () }
     }
 
     // MARK: PUT
 
-    func put<T: Decodable>(_ path: String) async -> Result<T, NetworkingError> {
+    public func put<T: Decodable>(_ path: String) async -> Result<T, NetworkingError> {
         return await handle(.put, path: path)
     }
 
-    func put(_ path: String) async -> Result<Void, NetworkingError> {
+    public func put(_ path: String) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await handle(.put, path: path)
         return result.map { _ in () }
     }
 
-    func put<B: Encodable, T: Decodable>(_ path: String, body: B) async -> Result<T, NetworkingError> {
+    public func put<B: Encodable, T: Decodable>(_ path: String, body: B) async -> Result<T, NetworkingError> {
         return await encodeAndHandle(.put, path: path, body: body)
     }
 
-    func put<B: Encodable>(_ path: String, body: B) async -> Result<Void, NetworkingError> {
+    public func put<B: Encodable>(_ path: String, body: B) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await encodeAndHandle(.put, path: path, body: body)
         return result.map { _ in () }
     }
 
-    func put<F: Encodable, T: Decodable>(_ path: String, form: F) async -> Result<T, NetworkingError> {
+    public func put<F: Encodable, T: Decodable>(_ path: String, form: F) async -> Result<T, NetworkingError> {
         return await formEncodeAndHandle(.put, path: path, form: form)
     }
 
-    func put<F: Encodable>(_ path: String, form: F) async -> Result<Void, NetworkingError> {
+    public func put<F: Encodable>(_ path: String, form: F) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await formEncodeAndHandle(.put, path: path, form: form)
         return result.map { _ in () }
     }
 
-    func put<T: Decodable>(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async -> Result<T, NetworkingError> {
+    public func put<T: Decodable>(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async
+        -> Result<T, NetworkingError>
+    {
         return await handle(.put, path: path, body: .multipart(fields: fields, parts: parts))
     }
 
-    func put(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await handle(.put, path: path, body: .multipart(fields: fields, parts: parts))
+    public func put(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async -> Result<
+        Void, NetworkingError
+    > {
+        let result: Result<Data, NetworkingError> = await handle(
+            .put, path: path, body: .multipart(fields: fields, parts: parts))
         return result.map { _ in () }
     }
 
-    func put<T: Decodable>(_ path: String, data: Data, contentType: String) async -> Result<T, NetworkingError> {
+    public func put<T: Decodable>(_ path: String, data: Data, contentType: String) async -> Result<T, NetworkingError> {
         return await handle(.put, path: path, body: .raw(data, contentType: contentType))
     }
 
-    func put(_ path: String, data: Data, contentType: String) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await handle(.put, path: path, body: .raw(data, contentType: contentType))
+    public func put(_ path: String, data: Data, contentType: String) async -> Result<Void, NetworkingError> {
+        let result: Result<Data, NetworkingError> = await handle(
+            .put, path: path, body: .raw(data, contentType: contentType))
         return result.map { _ in () }
     }
 
     // MARK: PATCH
 
-    func patch<T: Decodable>(_ path: String) async -> Result<T, NetworkingError> {
+    public func patch<T: Decodable>(_ path: String) async -> Result<T, NetworkingError> {
         return await handle(.patch, path: path)
     }
 
-    func patch(_ path: String) async -> Result<Void, NetworkingError> {
+    public func patch(_ path: String) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await handle(.patch, path: path)
         return result.map { _ in () }
     }
 
-    func patch<B: Encodable, T: Decodable>(_ path: String, body: B) async -> Result<T, NetworkingError> {
+    public func patch<B: Encodable, T: Decodable>(_ path: String, body: B) async -> Result<T, NetworkingError> {
         return await encodeAndHandle(.patch, path: path, body: body)
     }
 
-    func patch<B: Encodable>(_ path: String, body: B) async -> Result<Void, NetworkingError> {
+    public func patch<B: Encodable>(_ path: String, body: B) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await encodeAndHandle(.patch, path: path, body: body)
         return result.map { _ in () }
     }
 
-    func patch<F: Encodable, T: Decodable>(_ path: String, form: F) async -> Result<T, NetworkingError> {
+    public func patch<F: Encodable, T: Decodable>(_ path: String, form: F) async -> Result<T, NetworkingError> {
         return await formEncodeAndHandle(.patch, path: path, form: form)
     }
 
-    func patch<F: Encodable>(_ path: String, form: F) async -> Result<Void, NetworkingError> {
+    public func patch<F: Encodable>(_ path: String, form: F) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await formEncodeAndHandle(.patch, path: path, form: form)
         return result.map { _ in () }
     }
 
-    func patch<T: Decodable>(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async -> Result<T, NetworkingError> {
+    public func patch<T: Decodable>(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async
+        -> Result<T, NetworkingError>
+    {
         return await handle(.patch, path: path, body: .multipart(fields: fields, parts: parts))
     }
 
-    func patch(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await handle(.patch, path: path, body: .multipart(fields: fields, parts: parts))
+    public func patch(_ path: String, parts: [FormDataPart], fields: [String: String] = [:]) async -> Result<
+        Void, NetworkingError
+    > {
+        let result: Result<Data, NetworkingError> = await handle(
+            .patch, path: path, body: .multipart(fields: fields, parts: parts))
         return result.map { _ in () }
     }
 
-    func patch<T: Decodable>(_ path: String, data: Data, contentType: String) async -> Result<T, NetworkingError> {
+    public func patch<T: Decodable>(_ path: String, data: Data, contentType: String) async -> Result<T, NetworkingError>
+    {
         return await handle(.patch, path: path, body: .raw(data, contentType: contentType))
     }
 
-    func patch(_ path: String, data: Data, contentType: String) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await handle(.patch, path: path, body: .raw(data, contentType: contentType))
+    public func patch(_ path: String, data: Data, contentType: String) async -> Result<Void, NetworkingError> {
+        let result: Result<Data, NetworkingError> = await handle(
+            .patch, path: path, body: .raw(data, contentType: contentType))
         return result.map { _ in () }
     }
 
     // MARK: DELETE
 
-    func delete<T: Decodable>(_ path: String, query: [URLQueryItem]? = nil) async -> Result<T, NetworkingError> {
+    public func delete<T: Decodable>(_ path: String, query: [URLQueryItem]? = nil) async -> Result<T, NetworkingError> {
         return await handle(.delete, path: path, query: query ?? [])
     }
 
-    func delete(_ path: String, query: [URLQueryItem]? = nil) async -> Result<Void, NetworkingError> {
+    public func delete(_ path: String, query: [URLQueryItem]? = nil) async -> Result<Void, NetworkingError> {
         let result: Result<Data, NetworkingError> = await handle(.delete, path: path, query: query ?? [])
         return result.map { _ in () }
     }
 
-    func delete<Q: Encodable, T: Decodable>(_ path: String, query: Q) async -> Result<T, NetworkingError> {
+    public func delete<Q: Encodable, T: Decodable>(_ path: String, query: Q) async -> Result<T, NetworkingError> {
         return await queryEncodeAndHandle(.delete, path: path, query: query, cachingLevel: .none)
     }
 
-    func delete<Q: Encodable>(_ path: String, query: Q) async -> Result<Void, NetworkingError> {
-        let result: Result<Data, NetworkingError> = await queryEncodeAndHandle(.delete, path: path, query: query, cachingLevel: .none)
+    public func delete<Q: Encodable>(_ path: String, query: Q) async -> Result<Void, NetworkingError> {
+        let result: Result<Data, NetworkingError> = await queryEncodeAndHandle(
+            .delete, path: path, query: query, cachingLevel: .none)
         return result.map { _ in () }
     }
 }
@@ -184,12 +209,16 @@ extension Networking {
         return encoder
     }()
 
-    func encodeAndHandle<B: Encodable, T: Decodable>(_ requestType: RequestType, path: String, body: B) async -> Result<T, NetworkingError> {
+    func encodeAndHandle<B: Encodable, T: Decodable>(_ requestType: RequestType, path: String, body: B) async -> Result<
+        T, NetworkingError
+    > {
         let data: Data
         do {
             data = try Self.requestBodyEncoder.encode(body)
         } catch {
-            return emitPreflightFailure(requestType, path: path, error: .invalidRequest(.bodyEncodingFailed(message: error.localizedDescription)))
+            return emitPreflightFailure(
+                requestType, path: path,
+                error: .invalidRequest(.bodyEncodingFailed(message: error.localizedDescription)))
         }
         return await handle(requestType, path: path, body: .json(data))
     }
@@ -206,22 +235,30 @@ extension Networking {
 }
 
 extension Networking {
-    func formEncodeAndHandle<T: Decodable>(_ requestType: RequestType, path: String, form: some Encodable) async -> Result<T, NetworkingError> {
+    func formEncodeAndHandle<T: Decodable>(_ requestType: RequestType, path: String, form: some Encodable) async
+        -> Result<T, NetworkingError>
+    {
         let fields: [String: String]
         do {
             fields = try formFields(from: form)
         } catch {
-            return emitPreflightFailure(requestType, path: path, error: .invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
+            return emitPreflightFailure(
+                requestType, path: path,
+                error: .invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
         }
         return await handle(requestType, path: path, body: .formURLEncoded(fields))
     }
 
-    func queryEncodeAndHandle<T: Decodable>(_ requestType: RequestType, path: String, query: some Encodable, cachingLevel: CachingLevel) async -> Result<T, NetworkingError> {
+    func queryEncodeAndHandle<T: Decodable>(
+        _ requestType: RequestType, path: String, query: some Encodable, cachingLevel: CachingLevel
+    ) async -> Result<T, NetworkingError> {
         let items: [URLQueryItem]
         do {
             items = try formFields(from: query).map { URLQueryItem(name: $0.key, value: $0.value) }
         } catch {
-            return emitPreflightFailure(requestType, path: path, error: .invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
+            return emitPreflightFailure(
+                requestType, path: path,
+                error: .invalidRequest(.parameterEncodingFailed(message: error.localizedDescription)))
         }
         return await handle(requestType, path: path, query: items, cachingLevel: cachingLevel)
     }
@@ -229,98 +266,168 @@ extension Networking {
 
 // MARK: - Faking requests
 
-public extension Networking {
-    func fakeGET(_ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .get, path: path, headerFields: headerFields, payload: fakePayload(response), responseType: .json, statusCode: statusCode, delay: delay)
+extension Networking {
+    public func fakeGET(
+        _ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200,
+        delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .get, path: path, headerFields: headerFields, payload: fakePayload(response),
+            responseType: .json, statusCode: statusCode, delay: delay)
     }
 
-    func fakeGET(_ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .get, path: path, headerFields: headerFields, payload: .none, responseType: .json, statusCode: statusCode, delay: delay)
+    public func fakeGET(_ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0)
+    {
+        registerFake(
+            requestType: .get, path: path, headerFields: headerFields, payload: .none, responseType: .json,
+            statusCode: statusCode, delay: delay)
     }
 
-    func fakeGET(_ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .get, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
+    public func fakeGET(
+        _ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .get, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
     }
 
-    func fakePOST(_ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .post, path: path, headerFields: headerFields, payload: fakePayload(response), responseType: .json, statusCode: statusCode, delay: delay)
+    public func fakePOST(
+        _ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200,
+        delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .post, path: path, headerFields: headerFields, payload: fakePayload(response),
+            responseType: .json, statusCode: statusCode, delay: delay)
     }
 
-    func fakePOST(_ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .post, path: path, headerFields: headerFields, payload: .none, responseType: .json, statusCode: statusCode, delay: delay)
+    public func fakePOST(
+        _ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .post, path: path, headerFields: headerFields, payload: .none, responseType: .json,
+            statusCode: statusCode, delay: delay)
     }
 
-    func fakePOST(_ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .post, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
+    public func fakePOST(
+        _ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .post, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
     }
 
-    func fakePUT(_ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .put, path: path, headerFields: headerFields, payload: fakePayload(response), responseType: .json, statusCode: statusCode, delay: delay)
+    public func fakePUT(
+        _ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200,
+        delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .put, path: path, headerFields: headerFields, payload: fakePayload(response),
+            responseType: .json, statusCode: statusCode, delay: delay)
     }
 
-    func fakePUT(_ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .put, path: path, headerFields: headerFields, payload: .none, responseType: .json, statusCode: statusCode, delay: delay)
+    public func fakePUT(_ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0)
+    {
+        registerFake(
+            requestType: .put, path: path, headerFields: headerFields, payload: .none, responseType: .json,
+            statusCode: statusCode, delay: delay)
     }
 
-    func fakePUT(_ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .put, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
+    public func fakePUT(
+        _ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .put, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
     }
 
-    func fakePATCH(_ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .patch, path: path, headerFields: headerFields, payload: fakePayload(response), responseType: .json, statusCode: statusCode, delay: delay)
+    public func fakePATCH(
+        _ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200,
+        delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .patch, path: path, headerFields: headerFields, payload: fakePayload(response),
+            responseType: .json, statusCode: statusCode, delay: delay)
     }
 
-    func fakePATCH(_ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .patch, path: path, headerFields: headerFields, payload: .none, responseType: .json, statusCode: statusCode, delay: delay)
+    public func fakePATCH(
+        _ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .patch, path: path, headerFields: headerFields, payload: .none, responseType: .json,
+            statusCode: statusCode, delay: delay)
     }
 
-    func fakePATCH(_ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .patch, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
+    public func fakePATCH(
+        _ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .patch, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
     }
 
-    func fakeDELETE(_ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .delete, path: path, headerFields: headerFields, payload: fakePayload(response), responseType: .json, statusCode: statusCode, delay: delay)
+    public func fakeDELETE(
+        _ path: String, response: some Encodable, headerFields: [String: String]? = nil, statusCode: Int = 200,
+        delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .delete, path: path, headerFields: headerFields, payload: fakePayload(response),
+            responseType: .json, statusCode: statusCode, delay: delay)
     }
 
-    func fakeDELETE(_ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .delete, path: path, headerFields: headerFields, payload: .none, responseType: .json, statusCode: statusCode, delay: delay)
+    public func fakeDELETE(
+        _ path: String, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .delete, path: path, headerFields: headerFields, payload: .none, responseType: .json,
+            statusCode: statusCode, delay: delay)
     }
 
-    func fakeDELETE(_ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .delete, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
+    public func fakeDELETE(
+        _ path: String, fileName: String, bundle: Bundle = Bundle.main, statusCode: Int = 200, delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .delete, path: path, fileName: fileName, bundle: bundle, statusCode: statusCode, delay: delay)
     }
 }
 
 // MARK: - Downloads
 
-public extension Networking {
+extension Networking {
 
-    nonisolated func imageFromCache(_ path: String, cacheName: String? = nil) throws -> Image? {
-        let object = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: .memoryAndFile, responseType: .image)
+    public nonisolated func imageFromCache(_ path: String, cacheName: String? = nil) throws -> Image? {
+        let object = try objectFromCache(
+            for: path, cacheName: cacheName, cachingLevel: .memoryAndFile, responseType: .image)
 
         return object as? Image
     }
 
-    func downloadImage<T: ImageDownloadable>(_ path: String, cacheName: String? = nil, cachingLevel: CachingLevel = .memoryAndFile) async -> Result<T, NetworkingError> {
-        return await handleImageRequest(.get, path: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: .image)
+    public func downloadImage<T: ImageDownloadable>(
+        _ path: String, cacheName: String? = nil, cachingLevel: CachingLevel = .memoryAndFile
+    ) async -> Result<T, NetworkingError> {
+        return await handleImageRequest(
+            .get, path: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: .image)
     }
 
     /// Completes the in-flight download for `path` with `URLError.cancelled`.
-    func cancelImageDownload(_ path: String) async throws {
+    public func cancelImageDownload(_ path: String) async throws {
         let url = try composedURL(with: path)
         await cancelRequest(.data, requestType: .get, url: url)
     }
 
-    func fakeImageDownload(_ path: String, image: Image, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0) {
-        registerFake(requestType: .get, path: path, headerFields: headerFields, payload: .image(image), responseType: .image, statusCode: statusCode, delay: delay)
+    public func fakeImageDownload(
+        _ path: String, image: Image, headerFields: [String: String]? = nil, statusCode: Int = 200, delay: Double = 0
+    ) {
+        registerFake(
+            requestType: .get, path: path, headerFields: headerFields, payload: .image(image), responseType: .image,
+            statusCode: statusCode, delay: delay)
     }
 
-    func downloadData<T: DataDownloadable>(_ path: String, cacheName: String? = nil, cachingLevel: CachingLevel = .memoryAndFile) async -> Result<T, NetworkingError> {
-        return await handleDataRequest(.get, path: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: .data)
+    public func downloadData<T: DataDownloadable>(
+        _ path: String, cacheName: String? = nil, cachingLevel: CachingLevel = .memoryAndFile
+    ) async -> Result<T, NetworkingError> {
+        return await handleDataRequest(
+            .get, path: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: .data)
     }
 
-    nonisolated func dataFromCache(_ path: String, cacheName: String? = nil) throws -> Data? {
-        let object = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: .memoryAndFile, responseType: .data)
+    public nonisolated func dataFromCache(_ path: String, cacheName: String? = nil) throws -> Data? {
+        let object = try objectFromCache(
+            for: path, cacheName: cacheName, cachingLevel: .memoryAndFile, responseType: .data)
 
         return object as? Data
     }

--- a/Sources/Networking/Networking+New.swift
+++ b/Sources/Networking/Networking+New.swift
@@ -16,12 +16,15 @@ extension Networking {
             case .json: return "application/json"
             case .formURLEncoded: return "application/x-www-form-urlencoded"
             case .multipart: return "multipart/form-data; boundary=\(boundary)"
-            case let .raw(_, contentType): return contentType
+            case .raw(_, let contentType): return contentType
             }
         }
     }
 
-    func handle<T: Decodable>(_ requestType: RequestType, path: String, body: RequestBody = .none, query: [URLQueryItem] = [], cachingLevel: CachingLevel = .none) async -> Result<T, NetworkingError> {
+    func handle<T: Decodable>(
+        _ requestType: RequestType, path: String, body: RequestBody = .none, query: [URLQueryItem] = [],
+        cachingLevel: CachingLevel = .none
+    ) async -> Result<T, NetworkingError> {
         let requestID = UUID()
         let clock = ContinuousClock()
         let startInstant = clock.now
@@ -35,16 +38,19 @@ extension Networking {
 
         do {
             if let fakeRequest = try FakeRequest.find(ofType: requestType, forPath: path, in: fakeRequests) {
-                let fakeContext = RequestContext(id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
+                let fakeContext = RequestContext(
+                    id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
                 context = fakeContext
                 emit(.started(fakeContext))
-                let (fakeResult, fakeStatus, fakeBytes): (Result<T, NetworkingError>, Int, Int) = try await handleFakeRequest(fakeRequest, path: path, requestType: requestType)
+                let (fakeResult, fakeStatus, fakeBytes): (Result<T, NetworkingError>, Int, Int) =
+                    try await handleFakeRequest(fakeRequest, path: path, requestType: requestType)
                 result = fakeResult
                 statusCode = fakeStatus
                 byteCount = fakeBytes
             } else {
                 let request = try createRequest(path: path, requestType: requestType, body: body, query: query)
-                let requestContext = RequestContext(id: requestID, requestType: requestType, url: request.url, headers: request.allHTTPHeaderFields)
+                let requestContext = RequestContext(
+                    id: requestID, requestType: requestType, url: request.url, headers: request.allHTTPHeaderFields)
                 context = requestContext
                 emit(.started(requestContext))
 
@@ -52,12 +58,16 @@ extension Networking {
                 // the cacheName so destinationURL uses it verbatim instead of re-prepending the baseURL.
                 let cacheKey = cacheKey(for: request, fallbackPath: path)
                 if cachingLevel != .none,
-                    let cachedData = try objectFromCache(for: path, cacheName: cacheKey, cachingLevel: cachingLevel, responseType: .json) as? Data,
+                    let cachedData = try objectFromCache(
+                        for: path, cacheName: cacheKey, cachingLevel: cachingLevel, responseType: .json) as? Data,
                     let cached = try? JSONDecoder().decode(CachedResponse.self, from: cachedData),
                     let url = request.url,
-                    let cachedResponse = HTTPURLResponse(url: url, statusCode: cached.statusCode, httpVersion: nil, headerFields: cached.headers) {
+                    let cachedResponse = HTTPURLResponse(
+                        url: url, statusCode: cached.statusCode, httpVersion: nil, headerFields: cached.headers)
+                {
                     // Run the cache hit back out through the interceptor chain so validators apply to it too.
-                    let exchange = try await perform(request, cached: HTTPExchange(data: cached.body, response: cachedResponse))
+                    let exchange = try await perform(
+                        request, cached: HTTPExchange(data: cached.body, response: cachedResponse))
                     result = handleResponse(responseData: exchange.data, response: exchange.response, path: path)
                     statusCode = exchange.response.statusCode
                     byteCount = exchange.data.count
@@ -67,14 +77,20 @@ extension Networking {
                     let exchange = try await perform(request, collector: collector)
                     let responseData = exchange.data
                     let response: URLResponse = exchange.response
-                    let networkResult: Result<T, NetworkingError> = handleResponse(responseData: responseData, response: response, path: path)
-                    if cachingLevel != .none, case .success = networkResult, let httpResponse = response as? HTTPURLResponse {
-                        let headers = Dictionary(uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
-                            (key as? String).map { ($0, "\(value)") }
-                        })
-                        let envelope = CachedResponse(statusCode: httpResponse.statusCode, headers: headers, body: responseData)
+                    let networkResult: Result<T, NetworkingError> = handleResponse(
+                        responseData: responseData, response: response, path: path)
+                    if cachingLevel != .none, case .success = networkResult,
+                        let httpResponse = response as? HTTPURLResponse
+                    {
+                        let headers = Dictionary(
+                            uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
+                                (key as? String).map { ($0, "\(value)") }
+                            })
+                        let envelope = CachedResponse(
+                            statusCode: httpResponse.statusCode, headers: headers, body: responseData)
                         if let encoded = try? JSONEncoder().encode(envelope) {
-                            try? cacheOrPurgeData(data: encoded, path: path, cacheName: cacheKey, cachingLevel: cachingLevel)
+                            try? cacheOrPurgeData(
+                                data: encoded, path: path, cacheName: cacheKey, cachingLevel: cachingLevel)
                         }
                     }
                     result = networkResult
@@ -90,7 +106,8 @@ extension Networking {
             // A failure before the request context was built (e.g. URL building) still emits a paired
             // .started/.completed so observers see every request.
             if context == nil {
-                let errorContext = RequestContext(id: requestID, requestType: requestType, url: nil, headers: headerFields)
+                let errorContext = RequestContext(
+                    id: requestID, requestType: requestType, url: nil, headers: headerFields)
                 context = errorContext
                 emit(.started(errorContext))
             }
@@ -99,13 +116,17 @@ extension Networking {
 
         let duration = clock.now - startInstant
         guard let context else { return result }
-        return complete(result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: metrics, duration: duration, requestBody: body, responseMetadata: responseMetadata)
+        return complete(
+            result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: metrics,
+            duration: duration, requestBody: body, responseMetadata: responseMetadata)
     }
 
     // Runs the interceptor chain. On a cache hit, `cached` is the base result the chain folds around (no
     // network call), so validators still see it. session/collector are read into locals first so the
     // @Sendable chain captures no actor-isolated state (Swift 6 region isolation).
-    func perform(_ request: URLRequest, collector: MetricsCollector? = nil, cached: HTTPExchange? = nil) async throws -> HTTPExchange {
+    func perform(_ request: URLRequest, collector: MetricsCollector? = nil, cached: HTTPExchange? = nil) async throws
+        -> HTTPExchange
+    {
         let session = self.session
         let base: @Sendable (URLRequest) async throws -> HTTPExchange = { request in
             if let cached { return cached }
@@ -128,20 +149,29 @@ extension Networking {
 
     // The single completion path, shared by verbs, pre-flight failures, and downloads. `requestBody` and
     // `responseMetadata` aren't on the `.completed` event, so they're threaded here for logging only.
-    func complete<T>(_ result: Result<T, NetworkingError>, context: RequestContext, statusCode: Int?, byteCount: Int, metrics: TransactionMetrics?, duration: Duration, requestBody: RequestBody? = nil, responseMetadata: ResponseMetadata? = nil) -> Result<T, NetworkingError> {
+    func complete<T>(
+        _ result: Result<T, NetworkingError>, context: RequestContext, statusCode: Int?, byteCount: Int,
+        metrics: TransactionMetrics?, duration: Duration, requestBody: RequestBody? = nil,
+        responseMetadata: ResponseMetadata? = nil
+    ) -> Result<T, NetworkingError> {
         let outcome: Outcome
         switch result {
         case .success:
             outcome = .success(statusCode: statusCode ?? 0, byteCount: byteCount)
-        case let .failure(error):
+        case .failure(let error):
             outcome = .failure(error)
         }
-        logCompletion(context: context, result: result, statusCode: statusCode, byteCount: byteCount, duration: duration, requestBody: requestBody, responseMetadata: responseMetadata)
+        logCompletion(
+            context: context, result: result, statusCode: statusCode, byteCount: byteCount, duration: duration,
+            requestBody: requestBody, responseMetadata: responseMetadata)
         emit(.completed(context, outcome: outcome, duration: duration, metrics: metrics))
         return result
     }
 
-    private func logCompletion<T>(context: RequestContext, result: Result<T, NetworkingError>, statusCode: Int?, byteCount: Int, duration: Duration, requestBody: RequestBody?, responseMetadata: ResponseMetadata?) {
+    private func logCompletion<T>(
+        context: RequestContext, result: Result<T, NetworkingError>, statusCode: Int?, byteCount: Int,
+        duration: Duration, requestBody: RequestBody?, responseMetadata: ResponseMetadata?
+    ) {
         guard logLevel != .none else { return }
 
         let line: String
@@ -150,12 +180,14 @@ extension Networking {
         switch result {
         case .success:
             guard logLevel == .all else { return }
-            line = "✓ \(context.method) \(context.url?.absoluteString ?? "") [\(context.id.uuidString)] \(statusCode ?? 0) (\(byteCount) bytes) in \(duration)"
+            line =
+                "✓ \(context.method) \(context.url?.absoluteString ?? "") [\(context.id.uuidString)] \(statusCode ?? 0) (\(byteCount) bytes) in \(duration)"
             level = .info
             error = nil
-        case let .failure(failure):
+        case .failure(let failure):
             guard !failure.isCancelled else { return }
-            line = "✗ \(context.method) \(context.url?.absoluteString ?? "") [\(context.id.uuidString)] failed: \(failure.errorDescription ?? "request failed")"
+            line =
+                "✗ \(context.method) \(context.url?.absoluteString ?? "") [\(context.id.uuidString)] failed: \(failure.errorDescription ?? "request failed")"
             level = .error
             error = failure
         }
@@ -186,9 +218,9 @@ extension Networking {
         switch body {
         case .none:
             return nil
-        case let .json(data), let .raw(data, _):
+        case .json(let data), .raw(let data, _):
             return bodySnippet(from: data)
-        case let .formURLEncoded(fields):
+        case .formURLEncoded(let fields):
             return (try? fields.urlEncodedString()).flatMap { $0.isEmpty ? nil : $0 }
         case .multipart:
             return "<multipart/form-data>"
@@ -197,9 +229,12 @@ extension Networking {
 
     // Emits the `.started`/`.completed` pair for a failure that happens before the network call (e.g.
     // body encoding), so observers don't miss it.
-    func emitPreflightFailure<T: Decodable>(_ requestType: RequestType, path: String, error: NetworkingError) -> Result<T, NetworkingError> {
+    func emitPreflightFailure<T: Decodable>(_ requestType: RequestType, path: String, error: NetworkingError) -> Result<
+        T, NetworkingError
+    > {
         let requestID = UUID()
-        let context = RequestContext(id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
+        let context = RequestContext(
+            id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
         emit(.started(context))
         return complete(.failure(error), context: context, statusCode: nil, byteCount: 0, metrics: nil, duration: .zero)
     }
@@ -213,7 +248,8 @@ extension Networking {
 
     private func cacheKey(for request: URLRequest, fallbackPath: String) -> String {
         guard let url = request.url,
-              var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else {
             return fallbackPath
         }
         // Sort the *encoded* query components so parameter order doesn't change the key (a cache
@@ -224,7 +260,9 @@ extension Networking {
         return components.string ?? url.absoluteString
     }
 
-    private func handleFakeRequest<T: Decodable>(_ fakeRequest: FakeRequest, path: String, requestType: RequestType) async throws -> (Result<T, NetworkingError>, statusCode: Int, byteCount: Int) {
+    private func handleFakeRequest<T: Decodable>(_ fakeRequest: FakeRequest, path: String, requestType: RequestType)
+        async throws -> (Result<T, NetworkingError>, statusCode: Int, byteCount: Int)
+    {
         let (response, _) = try handleFakeRequest(fakeRequest, path: path, cacheName: nil, cachingLevel: .none)
 
         if fakeRequest.delay > 0 {
@@ -233,16 +271,19 @@ extension Networking {
 
         // handleResponse routes success/failure off the fake's HTTP status code, so an empty body is fine.
         let responseData: Data
-        if case let .data(data) = fakeRequest.payload {
+        if case .data(let data) = fakeRequest.payload {
             responseData = data
         } else {
             responseData = Data()
         }
-        let result: Result<T, NetworkingError> = handleResponse(responseData: responseData, response: response, path: path)
+        let result: Result<T, NetworkingError> = handleResponse(
+            responseData: responseData, response: response, path: path)
         return (result, response.statusCode, responseData.count)
     }
 
-    private func createRequest(path: String, requestType: RequestType, body: RequestBody, query: [URLQueryItem]) throws -> URLRequest {
+    private func createRequest(path: String, requestType: RequestType, body: RequestBody, query: [URLQueryItem]) throws
+        -> URLRequest
+    {
         // Split a query embedded in the path so it survives URL building instead of being
         // percent-encoded into the path (encodeUTF8 uses .urlPathAllowed, which escapes "?").
         let pathParts = path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
@@ -287,11 +328,11 @@ extension Networking {
         switch body {
         case .none:
             return nil
-        case let .json(data):
+        case .json(let data):
             return data
-        case let .formURLEncoded(parameters):
+        case .formURLEncoded(let parameters):
             return try parameters.urlEncodedString().data(using: .utf8)
-        case let .multipart(fields, parts):
+        case .multipart(let fields, let parts):
             var bodyData = Data()
             for (key, value) in fields {
                 var body = ""
@@ -306,12 +347,14 @@ extension Networking {
             }
             bodyData.append("--\(boundary)--\r\n".data(using: .utf8)!)
             return bodyData
-        case let .raw(data, _):
+        case .raw(let data, _):
             return data
         }
     }
 
-    private func handleResponse<T: Decodable>(responseData: Data, response: URLResponse, path: String) -> Result<T, NetworkingError> {
+    private func handleResponse<T: Decodable>(responseData: Data, response: URLResponse, path: String) -> Result<
+        T, NetworkingError
+    > {
         guard let httpResponse = response as? HTTPURLResponse else {
             return .failure(.invalidResponse)
         }
@@ -324,27 +367,32 @@ extension Networking {
         case .cancelled:
             return .failure(.cancelled)
         case .redirection, .clientError, .serverError, .unknown:
-            let error = HTTPError(statusCode: statusCode, metadata: ResponseMetadata(response: httpResponse, body: responseData))
+            let error = HTTPError(
+                statusCode: statusCode, metadata: ResponseMetadata(response: httpResponse, body: responseData))
             return .failure(.http(error))
         }
     }
 
-    private func handleSuccessfulResponse<T: Decodable>(responseData: Data, path: String, httpResponse: HTTPURLResponse) -> Result<T, NetworkingError> {
+    private func handleSuccessfulResponse<T: Decodable>(responseData: Data, path: String, httpResponse: HTTPURLResponse)
+        -> Result<T, NetworkingError>
+    {
         if T.self == Data.self {
             return .success(responseData as! T)
         } else if T.self == JSONResponse.self {
-            let headers = Dictionary(uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
-                (key as? String).map { ($0, AnyCodable(value)) }
-            })
+            let headers = Dictionary(
+                uniqueKeysWithValues: httpResponse.allHeaderFields.compactMap { key, value in
+                    (key as? String).map { ($0, AnyCodable(value)) }
+                })
             do {
                 // An empty body (e.g. 204 No Content) is a success — decoding empty data would fail, so use an empty body.
-                let body = responseData.isEmpty ? [:] : try JSONDecoder().decode([String: AnyCodable].self, from: responseData)
+                let body =
+                    responseData.isEmpty ? [:] : try JSONDecoder().decode([String: AnyCodable].self, from: responseData)
                 let networkingJSON = JSONResponse(statusCode: httpResponse.statusCode, headers: headers, body: body)
                 return .success(networkingJSON as! T)
             } catch let error as DecodingError {
                 return .failure(.decoding(error, ResponseMetadata(response: httpResponse, body: responseData)))
             } catch {
-                return .failure(.invalidResponse) // JSONDecoder only throws DecodingError; unreachable.
+                return .failure(.invalidResponse)  // JSONDecoder only throws DecodingError; unreachable.
             }
         } else {
             let decoder = JSONDecoder()
@@ -354,7 +402,7 @@ extension Networking {
             } catch let error as DecodingError {
                 return .failure(.decoding(error, ResponseMetadata(response: httpResponse, body: responseData)))
             } catch {
-                return .failure(.invalidResponse) // JSONDecoder only throws DecodingError; unreachable.
+                return .failure(.invalidResponse)  // JSONDecoder only throws DecodingError; unreachable.
             }
         }
     }
@@ -362,7 +410,6 @@ extension Networking {
     private func bodySnippet(from data: Data, limit: Int = 512) -> String? {
         ResponseMetadata.bodySnippet(from: data, limit: limit)
     }
-
 
     private func mapThrownError<T: Decodable>(_ error: Error, path: String) -> Result<T, NetworkingError> {
         // An interceptor (or the network call) may throw an already-categorized error — pass it through intact.

--- a/Sources/Networking/Networking+Private.swift
+++ b/Sources/Networking/Networking+Private.swift
@@ -1,37 +1,54 @@
 import Foundation
 
 extension Networking {
-    nonisolated func objectFromCache(for path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) throws -> Any? {
-        try cacheStore.object(forResource: cacheResource(for: path, cacheName: cacheName), level: cachingLevel, asImage: responseType == .image)
+    nonisolated func objectFromCache(
+        for path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType
+    ) throws -> Any? {
+        try cacheStore.object(
+            forResource: cacheResource(for: path, cacheName: cacheName), level: cachingLevel,
+            asImage: responseType == .image)
     }
 
-    func registerFake(requestType: RequestType, path: String, fileName: String, bundle: Bundle, statusCode: Int, delay: Double) {
+    func registerFake(
+        requestType: RequestType, path: String, fileName: String, bundle: Bundle, statusCode: Int, delay: Double
+    ) {
         let url = URL(string: fileName)
         guard let resource = url?.deletingPathExtension().absoluteString,
-              let filePath = bundle.path(forResource: resource, ofType: url?.pathExtension),
-              let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)) else {
+            let filePath = bundle.path(forResource: resource, ofType: url?.pathExtension),
+            let data = try? Data(contentsOf: URL(fileURLWithPath: filePath))
+        else {
             fatalError("We couldn't find \(fileName), are you sure is there?")
         }
-        registerFake(requestType: requestType, path: path, headerFields: nil, payload: .data(data), responseType: .json, statusCode: statusCode, delay: delay)
+        registerFake(
+            requestType: requestType, path: path, headerFields: nil, payload: .data(data), responseType: .json,
+            statusCode: statusCode, delay: delay)
     }
 
-    func registerFake(requestType: RequestType, path: String, headerFields: [String: String]?, payload: FakeRequest.Payload, responseType: ResponseType, statusCode: Int, delay: Double) {
+    func registerFake(
+        requestType: RequestType, path: String, headerFields: [String: String]?, payload: FakeRequest.Payload,
+        responseType: ResponseType, statusCode: Int, delay: Double
+    ) {
         var requests = fakeRequests[requestType] ?? [String: FakeRequest]()
-        requests[path] = FakeRequest(payload: payload, responseType: responseType, headerFields: headerFields, statusCode: statusCode, delay: delay)
+        requests[path] = FakeRequest(
+            payload: payload, responseType: responseType, headerFields: headerFields, statusCode: statusCode,
+            delay: delay)
         fakeRequests[requestType] = requests
     }
 
-    func handleFakeRequest(_ fakeRequest: FakeRequest, path: String, cacheName: String?, cachingLevel: CachingLevel) throws -> (HTTPURLResponse, NSError?) {
+    func handleFakeRequest(_ fakeRequest: FakeRequest, path: String, cacheName: String?, cachingLevel: CachingLevel)
+        throws -> (HTTPURLResponse, NSError?)
+    {
         var error: NSError?
         let url = try composedURL(with: path)
-        let response = HTTPURLResponse(url: url, headerFields: fakeRequest.headerFields, statusCode: fakeRequest.statusCode)
+        let response = HTTPURLResponse(
+            url: url, headerFields: fakeRequest.headerFields, statusCode: fakeRequest.statusCode)
 
         if StatusCodeType(statusCode: fakeRequest.statusCode) != .successful {
             error = NSError(statusCode: fakeRequest.statusCode)
         }
 
         // Images are served directly by handleImageRequest, so there's nothing to cache here.
-        let data: Data? = { if case let .data(data) = fakeRequest.payload { return data } else { return nil } }()
+        let data: Data? = { if case .data(let data) = fakeRequest.payload { return data } else { return nil } }()
         switch fakeRequest.responseType {
         case .image:
             try cacheOrPurgeImage(data: nil, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
@@ -41,12 +58,15 @@ extension Networking {
         return (response, error)
     }
 
-
-    func handleDataRequest<T: DataDownloadable>(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) async -> Result<T, NetworkingError> {
+    func handleDataRequest<T: DataDownloadable>(
+        _ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel,
+        responseType: ResponseType
+    ) async -> Result<T, NetworkingError> {
         let requestID = UUID()
         let clock = ContinuousClock()
         let startInstant = clock.now
-        let context = RequestContext(id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
+        let context = RequestContext(
+            id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
         emit(.started(context))
 
         let result: Result<T, NetworkingError>
@@ -54,45 +74,62 @@ extension Networking {
         var byteCount = 0
         do {
             if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
-                let (fakeResponse, _) = try handleFakeRequest(fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
+                let (fakeResponse, _) = try handleFakeRequest(
+                    fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
                 if fakeRequest.delay > 0 {
                     try? await Task.sleep(nanoseconds: UInt64(fakeRequest.delay * 1_000_000_000))
                 }
                 statusCode = fakeResponse.statusCode
                 if StatusCodeType(statusCode: fakeResponse.statusCode) != .successful {
                     result = .failure(downloadError(forStatusCode: fakeResponse.statusCode))
-                } else if case let .data(fakeData) = fakeRequest.payload {
+                } else if case .data(let fakeData) = fakeRequest.payload {
                     byteCount = fakeData.count
-                    result = .success(T.makeDownloadResult(data: fakeData, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse)))
+                    result = .success(
+                        T.makeDownloadResult(
+                            data: fakeData, statusCode: fakeResponse.statusCode,
+                            headers: headerFields(from: fakeResponse)))
                 } else {
                     result = .failure(.invalidResponse)
                 }
-            } else if let cached = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Data {
+            } else if let cached = try objectFromCache(
+                for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Data
+            {
                 let response = HTTPURLResponse(url: try composedURL(with: path), statusCode: 200)
                 statusCode = 200
-                result = .success(T.makeDownloadResult(data: cached, statusCode: 200, headers: headerFields(from: response)))
+                result = .success(
+                    T.makeDownloadResult(data: cached, statusCode: 200, headers: headerFields(from: response)))
             } else {
-                let (downloaded, networkResponse) = try await requestData(requestType, path: path, responseType: responseType)
+                let (downloaded, networkResponse) = try await requestData(
+                    requestType, path: path, responseType: responseType)
                 try cacheOrPurgeData(data: downloaded, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
                 statusCode = networkResponse.statusCode
                 if StatusCodeType(statusCode: networkResponse.statusCode) != .successful {
                     result = .failure(downloadError(forStatusCode: networkResponse.statusCode))
                 } else {
                     byteCount = downloaded.count
-                    result = .success(T.makeDownloadResult(data: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse)))
+                    result = .success(
+                        T.makeDownloadResult(
+                            data: downloaded, statusCode: networkResponse.statusCode,
+                            headers: headerFields(from: networkResponse)))
                 }
             }
         } catch {
             result = .failure(downloadError(error))
         }
-        return complete(result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: nil, duration: clock.now - startInstant)
+        return complete(
+            result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: nil,
+            duration: clock.now - startInstant)
     }
 
-    func handleImageRequest<T: ImageDownloadable>(_ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel, responseType: ResponseType) async -> Result<T, NetworkingError> {
+    func handleImageRequest<T: ImageDownloadable>(
+        _ requestType: RequestType, path: String, cacheName: String?, cachingLevel: CachingLevel,
+        responseType: ResponseType
+    ) async -> Result<T, NetworkingError> {
         let requestID = UUID()
         let clock = ContinuousClock()
         let startInstant = clock.now
-        let context = RequestContext(id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
+        let context = RequestContext(
+            id: requestID, requestType: requestType, url: try? composedURL(with: path), headers: headerFields)
         emit(.started(context))
 
         let result: Result<T, NetworkingError>
@@ -100,30 +137,42 @@ extension Networking {
         var byteCount = 0
         do {
             if let fakeRequests = fakeRequests[requestType], let fakeRequest = fakeRequests[path] {
-                let (fakeResponse, _) = try handleFakeRequest(fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
+                let (fakeResponse, _) = try handleFakeRequest(
+                    fakeRequest, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
                 if fakeRequest.delay > 0 {
                     try? await Task.sleep(nanoseconds: UInt64(fakeRequest.delay * 1_000_000_000))
                 }
                 statusCode = fakeResponse.statusCode
                 if StatusCodeType(statusCode: fakeResponse.statusCode) != .successful {
                     result = .failure(downloadError(forStatusCode: fakeResponse.statusCode))
-                } else if case let .image(fakeImage) = fakeRequest.payload {
-                    result = .success(T.makeDownloadResult(image: fakeImage, statusCode: fakeResponse.statusCode, headers: headerFields(from: fakeResponse)))
+                } else if case .image(let fakeImage) = fakeRequest.payload {
+                    result = .success(
+                        T.makeDownloadResult(
+                            image: fakeImage, statusCode: fakeResponse.statusCode,
+                            headers: headerFields(from: fakeResponse)))
                 } else {
                     result = .failure(.invalidResponse)
                 }
-            } else if let cached = try objectFromCache(for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Image {
+            } else if let cached = try objectFromCache(
+                for: path, cacheName: cacheName, cachingLevel: cachingLevel, responseType: responseType) as? Image
+            {
                 let response = HTTPURLResponse(url: try composedURL(with: path), statusCode: 200)
                 statusCode = 200
-                result = .success(T.makeDownloadResult(image: cached, statusCode: 200, headers: headerFields(from: response)))
+                result = .success(
+                    T.makeDownloadResult(image: cached, statusCode: 200, headers: headerFields(from: response)))
             } else {
                 let (data, networkResponse) = try await requestData(requestType, path: path, responseType: responseType)
                 statusCode = networkResponse.statusCode
                 if StatusCodeType(statusCode: networkResponse.statusCode) != .successful {
                     result = .failure(downloadError(forStatusCode: networkResponse.statusCode))
-                } else if let downloaded = try cacheOrPurgeImage(data: data, path: path, cacheName: cacheName, cachingLevel: cachingLevel) {
+                } else if let downloaded = try cacheOrPurgeImage(
+                    data: data, path: path, cacheName: cacheName, cachingLevel: cachingLevel)
+                {
                     byteCount = data.count
-                    result = .success(T.makeDownloadResult(image: downloaded, statusCode: networkResponse.statusCode, headers: headerFields(from: networkResponse)))
+                    result = .success(
+                        T.makeDownloadResult(
+                            image: downloaded, statusCode: networkResponse.statusCode,
+                            headers: headerFields(from: networkResponse)))
                 } else {
                     result = .failure(.invalidResponse)
                 }
@@ -131,13 +180,16 @@ extension Networking {
         } catch {
             result = .failure(downloadError(error))
         }
-        return complete(result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: nil, duration: clock.now - startInstant)
+        return complete(
+            result, context: context, statusCode: statusCode, byteCount: byteCount, metrics: nil,
+            duration: clock.now - startInstant)
     }
 
     private func headerFields(from response: HTTPURLResponse) -> [String: AnyCodable] {
-        Dictionary(uniqueKeysWithValues: response.allHeaderFields.compactMap { key, value in
-            (key as? String).map { ($0, AnyCodable(value)) }
-        })
+        Dictionary(
+            uniqueKeysWithValues: response.allHeaderFields.compactMap { key, value in
+                (key as? String).map { ($0, AnyCodable(value)) }
+            })
     }
 
     private func downloadError(forStatusCode statusCode: Int) -> NetworkingError {
@@ -156,8 +208,13 @@ extension Networking {
         return .transport(URLError(.unknown))
     }
 
-    func requestData(_ requestType: RequestType, path: String, responseType: ResponseType) async throws -> (Data, HTTPURLResponse) {
-        let request = URLRequest(url: try composedURL(with: path), requestType: requestType, contentType: nil, responseType: responseType, authorizationHeaderValue: authorizationHeaderValue, token: token, authorizationHeaderKey: authorizationHeaderKey, headerFields: headerFields)
+    func requestData(_ requestType: RequestType, path: String, responseType: ResponseType) async throws -> (
+        Data, HTTPURLResponse
+    ) {
+        let request = URLRequest(
+            url: try composedURL(with: path), requestType: requestType, contentType: nil, responseType: responseType,
+            authorizationHeaderValue: authorizationHeaderValue, token: token,
+            authorizationHeaderKey: authorizationHeaderKey, headerFields: headerFields)
 
         // Route through the interceptor chain so retry/auth-refresh apply to downloads too. Caching is the
         // caller's job (handleDataRequest/handleImageRequest write under the real cacheName) — writing here
@@ -179,19 +236,25 @@ extension Networking {
         }
 
         for sessionTask in sessionTasks {
-            if sessionTask.originalRequest?.httpMethod == requestType.rawValue && sessionTask.originalRequest?.url?.absoluteString == url.absoluteString {
+            if sessionTask.originalRequest?.httpMethod == requestType.rawValue
+                && sessionTask.originalRequest?.url?.absoluteString == url.absoluteString
+            {
                 sessionTask.cancel()
                 break
             }
         }
     }
 
-    nonisolated func cacheOrPurgeData(data: Data?, path: String, cacheName: String?, cachingLevel: CachingLevel) throws {
+    nonisolated func cacheOrPurgeData(data: Data?, path: String, cacheName: String?, cachingLevel: CachingLevel) throws
+    {
         try cacheStore.storeData(data, forResource: cacheResource(for: path, cacheName: cacheName), level: cachingLevel)
     }
 
     @discardableResult
-    nonisolated func cacheOrPurgeImage(data: Data?, path: String, cacheName: String?, cachingLevel: CachingLevel) throws -> Image? {
-        try cacheStore.storeImage(data: data, forResource: cacheResource(for: path, cacheName: cacheName), level: cachingLevel)
+    nonisolated func cacheOrPurgeImage(data: Data?, path: String, cacheName: String?, cachingLevel: CachingLevel) throws
+        -> Image?
+    {
+        try cacheStore.storeImage(
+            data: data, forResource: cacheResource(for: path, cacheName: cacheName), level: cachingLevel)
     }
 }

--- a/Sources/Networking/Networking.swift
+++ b/Sources/Networking/Networking.swift
@@ -1,21 +1,21 @@
 import Foundation
 import os.log
 
-public extension Networking.StatusCodeType {
+extension Networking.StatusCodeType {
     /// Classifies an HTTP status code (with `URLError.cancelled` mapped to `.cancelled`).
-    init(statusCode: Int) {
+    public init(statusCode: Int) {
         switch statusCode {
         case URLError.cancelled.rawValue:
             self = .cancelled
-        case 100 ..< 200:
+        case 100..<200:
             self = .informational
-        case 200 ..< 300:
+        case 200..<300:
             self = .successful
-        case 300 ..< 400:
+        case 300..<400:
             self = .redirection
-        case 400 ..< 500:
+        case 400..<500:
             self = .clientError
-        case 500 ..< 600:
+        case 500..<600:
             self = .serverError
         default:
             self = .unknown
@@ -27,7 +27,11 @@ public actor Networking {
     static let domain = "com.3lvis.networking"
 
     enum RequestType: String {
-        case get = "GET", post = "POST", put = "PUT", patch = "PATCH", delete = "DELETE"
+        case get = "GET"
+        case post = "POST"
+        case put = "PUT"
+        case patch = "PATCH"
+        case delete = "DELETE"
     }
 
     enum SessionTaskType: String {
@@ -69,7 +73,8 @@ public actor Networking {
     /// A stream of observability events — one `.started` then one `.completed` per request. Each call
     /// returns its own multicast stream; the buffer keeps the newest 256 events for a slow consumer.
     public func events() -> AsyncStream<NetworkingEvent> {
-        let (stream, continuation) = AsyncStream.makeStream(of: NetworkingEvent.self, bufferingPolicy: .bufferingNewest(256))
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: NetworkingEvent.self, bufferingPolicy: .bufferingNewest(256))
         let id = UUID()
         streamContinuations[id] = continuation
         continuation.onTermination = { [weak self] _ in
@@ -98,9 +103,9 @@ public actor Networking {
 
     private static let defaultRedactsLogs: Bool = {
         #if DEBUG
-        return false
+            return false
         #else
-        return true
+            return true
         #endif
     }()
 
@@ -182,14 +187,19 @@ public actor Networking {
         cacheStore.setTTL(ttl)
     }
 
-    public init(baseURL: String = "", configuration: URLSessionConfiguration = .default, cache: NSCache<AnyObject, AnyObject>? = nil, logger: Logger? = nil, cacheTTL: Duration = .seconds(7 * 24 * 60 * 60)) {
+    public init(
+        baseURL: String = "", configuration: URLSessionConfiguration = .default,
+        cache: NSCache<AnyObject, AnyObject>? = nil, logger: Logger? = nil,
+        cacheTTL: Duration = .seconds(7 * 24 * 60 * 60)
+    ) {
         self.baseURL = baseURL
         self.configuration = configuration
         let memoryCache = cache ?? NSCache()
         self.cache = memoryCache
         self.cacheStore = CacheStore(memory: memoryCache, ttl: cacheTTL, folderName: Networking.domain)
         self.logger = logger ?? Networking.defaultLogger
-        self.logFileURL = ProcessInfo.processInfo.environment["NETWORKING_LOG_FILE"].flatMap(Networking.resolveLogFileURL)
+        self.logFileURL = ProcessInfo.processInfo.environment["NETWORKING_LOG_FILE"].flatMap(
+            Networking.resolveLogFileURL)
         // Sweep aged-out files off the request path so the disk cache can't grow without bound (one shard
         // per launch — see `CacheStore.sweepExpired`).
         let store = self.cacheStore
@@ -270,8 +280,9 @@ public actor Networking {
 
     public static func splitBaseURLAndRelativePath(for path: String) -> (baseURL: String, relativePath: String)? {
         guard let encodedPath = path.encodeUTF8(),
-              let url = URL(string: encodedPath),
-              let baseURLWithDash = URL(string: "/", relativeTo: url)?.absoluteURL.absoluteString else {
+            let url = URL(string: encodedPath),
+            let baseURLWithDash = URL(string: "/", relativeTo: url)?.absoluteURL.absoluteString
+        else {
             return nil
         }
         let index = baseURLWithDash.index(before: baseURLWithDash.endIndex)
@@ -298,8 +309,8 @@ public actor Networking {
     }
 }
 
-public extension Networking {
-    func cancelAllRequests() async {
+extension Networking {
+    public func cancelAllRequests() async {
         let (dataTasks, uploadTasks, downloadTasks) = await session.tasks
         for sessionTask in dataTasks {
             sessionTask.cancel()

--- a/Sources/Networking/NetworkingError.swift
+++ b/Sources/Networking/NetworkingError.swift
@@ -18,37 +18,37 @@ public enum NetworkingError: Error {
     case cancelled
 }
 
-public extension NetworkingError {
+extension NetworkingError {
     /// The HTTP status code, when the failure carries one.
-    var statusCode: Int? {
+    public var statusCode: Int? {
         switch self {
-        case let .http(error): return error.statusCode
-        case let .decoding(_, metadata): return metadata.statusCode
-        case let .validation(_, metadata): return metadata.statusCode
+        case .http(let error): return error.statusCode
+        case .decoding(_, let metadata): return metadata.statusCode
+        case .validation(_, let metadata): return metadata.statusCode
         default: return nil
         }
     }
 
-    var isCancelled: Bool {
+    public var isCancelled: Bool {
         if case .cancelled = self { return true }
         return false
     }
 
     /// The response metadata, when the failure carries a response.
-    var responseMetadata: ResponseMetadata? {
+    public var responseMetadata: ResponseMetadata? {
         switch self {
-        case let .http(error): return error.metadata
-        case let .decoding(_, metadata): return metadata
-        case let .validation(_, metadata): return metadata
+        case .http(let error): return error.metadata
+        case .decoding(_, let metadata): return metadata
+        case .validation(_, let metadata): return metadata
         default: return nil
         }
     }
 
     /// The default statuses `RetryInterceptor` retries, and the source of truth for `isRetryable`.
-    static let retryableStatusCodes: Set<Int> = [408, 429, 500, 502, 503, 504]
+    public static let retryableStatusCodes: Set<Int> = [408, 429, 500, 502, 503, 504]
 
     /// Whether a transport failure is transient (a dropped connection or timeout) and so worth retrying.
-    static func isRetryableTransport(_ error: URLError) -> Bool {
+    public static func isRetryableTransport(_ error: URLError) -> Bool {
         switch error.code {
         case .timedOut, .networkConnectionLost, .cannotConnectToHost, .dnsLookupFailed:
             return true
@@ -59,11 +59,11 @@ public extension NetworkingError {
 
     /// Whether retrying might plausibly succeed. Conservative: only transient transport failures and
     /// `retryableStatusCodes` — never decoding, invalid-request, invalid-response, or cancellation.
-    var isRetryable: Bool {
+    public var isRetryable: Bool {
         switch self {
-        case let .transport(error):
+        case .transport(let error):
             return Self.isRetryableTransport(error)
-        case let .http(error):
+        case .http(let error):
             return Self.retryableStatusCodes.contains(error.statusCode)
         case .invalidRequest, .decoding, .validation, .invalidResponse, .cancelled:
             return false
@@ -89,8 +89,8 @@ public struct HTTPError: Error, Sendable {
         self.metadata = metadata
     }
 
-    public var isClientError: Bool { (400 ..< 500).contains(statusCode) }
-    public var isServerError: Bool { (500 ..< 600).contains(statusCode) }
+    public var isClientError: Bool { (400..<500).contains(statusCode) }
+    public var isServerError: Bool { (500..<600).contains(statusCode) }
 }
 
 /// Metadata about an HTTP response, retained on failures for inspection, logging, and debugging.
@@ -106,9 +106,10 @@ public struct ResponseMetadata: Sendable {
     }
 
     public init(response: HTTPURLResponse, body: Data) {
-        let headers = Dictionary(uniqueKeysWithValues: response.allHeaderFields.compactMap { key, value in
-            (key as? String).map { ($0, "\(value)") }
-        })
+        let headers = Dictionary(
+            uniqueKeysWithValues: response.allHeaderFields.compactMap { key, value in
+                (key as? String).map { ($0, "\(value)") }
+            })
         self.init(statusCode: response.statusCode, headers: headers, body: body)
     }
 
@@ -131,22 +132,23 @@ public struct ResponseMetadata: Sendable {
 extension NetworkingError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case let .invalidRequest(reason):
+        case .invalidRequest(let reason):
             switch reason {
-            case let .invalidURL(path):
+            case .invalidURL(let path):
                 return "The request URL is invalid: \(path)."
-            case let .bodyEncodingFailed(message):
+            case .bodyEncodingFailed(let message):
                 return "Failed to encode the request body: \(message)"
-            case let .parameterEncodingFailed(message):
+            case .parameterEncodingFailed(let message):
                 return "Failed to encode the request parameters: \(message)"
             }
-        case let .transport(error):
+        case .transport(let error):
             return "A network error occurred: \(error.localizedDescription)"
-        case let .http(error):
-            return "The server returned status \(error.statusCode) (\(HTTPURLResponse.localizedString(forStatusCode: error.statusCode)))."
-        case let .decoding(error, metadata):
+        case .http(let error):
+            return
+                "The server returned status \(error.statusCode) (\(HTTPURLResponse.localizedString(forStatusCode: error.statusCode)))."
+        case .decoding(let error, let metadata):
             return "Failed to decode the response (status \(metadata.statusCode)): \(error.detailedMessage)"
-        case let .validation(reason, metadata):
+        case .validation(let reason, let metadata):
             return "The response (status \(metadata.statusCode)) failed validation: \(reason)"
         case .invalidResponse:
             return "The server returned a response that wasn't valid HTTP."

--- a/Sources/Networking/NetworkingEvent.swift
+++ b/Sources/Networking/NetworkingEvent.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-public extension Networking {
+extension Networking {
     /// Scope of the built-in diagnostics. Logged requests always get *full* detail; the level only
     /// chooses *which* requests: `.none` (nothing), `.failures` (the default), or `.all`.
-    enum LogLevel: Sendable {
+    public enum LogLevel: Sendable {
         case none
         case failures
         case all
@@ -84,12 +84,14 @@ final class MetricsCollector: NSObject, URLSessionTaskDelegate, @unchecked Senda
     private var collected: URLSessionTaskMetrics?
 
     var metrics: URLSessionTaskMetrics? {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         return collected
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        lock.lock(); defer { lock.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
         collected = metrics
     }
 }

--- a/Tests/NetworkingTests/AuthRefreshInterceptorIntegrationTests.swift
+++ b/Tests/NetworkingTests/AuthRefreshInterceptorIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 // go-httpbin's /bearer returns 401 without an `Authorization: Bearer …` header and 200 with one — so it
@@ -18,9 +19,9 @@ final class AuthRefreshInterceptorIntegrationTests: XCTestCase {
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/bearer")
 
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.statusCode, 200, "the replay with a fresh credential should succeed")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail("expected the refreshed replay to succeed, got \(error)")
         }
     }

--- a/Tests/NetworkingTests/AuthRefreshSingleFlightIntegrationTests.swift
+++ b/Tests/NetworkingTests/AuthRefreshSingleFlightIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 // When many requests hit an expired credential at once, they must share a single refresh rather than each

--- a/Tests/NetworkingTests/CacheStoreTests.swift
+++ b/Tests/NetworkingTests/CacheStoreTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Networking
 
 // Unit tests for the cache store itself — layout, the sliding-TTL expiry, the pure-read contracts, and
@@ -7,7 +8,9 @@ import XCTest
 final class CacheStoreTests: XCTestCase {
     private let folderName = "com.3lvis.networking.cachestoretests"
 
-    private func makeStore(ttl: Duration = .seconds(7 * 24 * 60 * 60)) throws -> (store: CacheStore, memory: NSCache<AnyObject, AnyObject>) {
+    private func makeStore(ttl: Duration = .seconds(7 * 24 * 60 * 60)) throws -> (
+        store: CacheStore, memory: NSCache<AnyObject, AnyObject>
+    ) {
         let memory = NSCache<AnyObject, AnyObject>()
         let store = CacheStore(memory: memory, ttl: ttl, folderName: folderName)
         try store.clear()
@@ -39,7 +42,8 @@ final class CacheStoreTests: XCTestCase {
 
         let url = try store.destinationURL(forResource: resource)
         memory.removeObject(forKey: url.absoluteString as AnyObject)  // force the disk path
-        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: url.path)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -120)], ofItemAtPath: url.path)
 
         XCTAssertNil(
             try store.object(forResource: resource, level: .memoryAndFile, asImage: false),
@@ -55,7 +59,8 @@ final class CacheStoreTests: XCTestCase {
 
         let url = try store.destinationURL(forResource: resource)
         memory.removeObject(forKey: url.absoluteString as AnyObject)  // force the disk path
-        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSinceNow: -30)], ofItemAtPath: url.path)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -30)], ofItemAtPath: url.path)
 
         XCTAssertNotNil(try store.object(forResource: resource, level: .memoryAndFile, asImage: false))
         let mtime = try url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate!

--- a/Tests/NetworkingTests/CacheWriteAndDataBodyRegressionTests.swift
+++ b/Tests/NetworkingTests/CacheWriteAndDataBodyRegressionTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Networking
 
 // Regressions for cache-write and Data-body bugs found in review; each test names the contract it guards.
@@ -34,7 +35,7 @@ final class CacheWriteAndDataBodyRegressionTests: XCTestCase {
         await networking.fakeGET("/payload", response: ["message": "hello"])
 
         let result: Result<Data, NetworkingError> = await networking.get("/payload")
-        guard case let .success(data) = result else { return XCTFail("expected success, got \(result)") }
+        guard case .success(let data) = result else { return XCTFail("expected success, got \(result)") }
 
         let decoded = try? JSONDecoder().decode([String: String].self, from: data)
         XCTAssertEqual(decoded?["message"], "hello", "a verb with T == Data must return the response body")

--- a/Tests/NetworkingTests/CancellationIntegrationTests.swift
+++ b/Tests/NetworkingTests/CancellationIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class CancellationIntegrationTests: XCTestCase {

--- a/Tests/NetworkingTests/DELETEIntegrationTests.swift
+++ b/Tests/NetworkingTests/DELETEIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class DELETEIntegrationTests: XCTestCase {
@@ -9,10 +10,10 @@ class DELETEIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let result: Result<JSONResponse, NetworkingError> = await networking.delete("/delete")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/delete")
             XCTAssertNil(httpbinEchoedMap(response, "headers")["Content-Type"])
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -21,10 +22,10 @@ class DELETEIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let result: Result<JSONResponse, NetworkingError> = await networking.delete("/delete")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/delete")
             XCTAssertTrue(response.headers.string(for: "Content-Type")?.hasPrefix("application/json") ?? false)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -35,8 +36,8 @@ class DELETEIntegrationTests: XCTestCase {
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 404)
@@ -45,11 +46,12 @@ class DELETEIntegrationTests: XCTestCase {
 
     func testDELETEWithURLEncodedParameters() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.delete("/delete", query: [URLQueryItem(name: "userId", value: "25")])
+        let result: Result<JSONResponse, NetworkingError> = await networking.delete(
+            "/delete", query: [URLQueryItem(name: "userId", value: "25")])
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/delete?userId=25")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }

--- a/Tests/NetworkingTests/Dictionary+FormURLEncodedTests.swift
+++ b/Tests/NetworkingTests/Dictionary+FormURLEncodedTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class Dictionary_FormURLEncodedTests: XCTestCase {

--- a/Tests/NetworkingTests/DownloadEventsIntegrationTests.swift
+++ b/Tests/NetworkingTests/DownloadEventsIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 final class DownloadEventsIntegrationTests: XCTestCase {
@@ -16,8 +17,9 @@ final class DownloadEventsIntegrationTests: XCTestCase {
 
         let events = await stream.collect(2)
         XCTAssertEqual(events.count, 2, "downloadImage should emit .started and .completed; got \(events)")
-        guard case let .started(startContext) = events.first,
-              case let .completed(endContext, outcome, _, _) = events.last else {
+        guard case .started(let startContext) = events.first,
+            case .completed(let endContext, let outcome, _, _) = events.last
+        else {
             return XCTFail("expected .started then .completed, got \(events)")
         }
         XCTAssertEqual(startContext.id, endContext.id)
@@ -35,10 +37,10 @@ final class DownloadEventsIntegrationTests: XCTestCase {
         let _: Result<Image, NetworkingError> = await networking.downloadImage("/image/png")
 
         let events = await stream.collect(2)
-        guard case let .completed(_, outcome, _, _) = events.last else {
+        guard case .completed(_, let outcome, _, _) = events.last else {
             return XCTFail("expected a .completed event, got \(events)")
         }
-        guard case let .failure(error) = outcome, case .http = error else {
+        guard case .failure(let error) = outcome, case .http = error else {
             return XCTFail("expected an HTTP failure outcome, got \(outcome)")
         }
     }

--- a/Tests/NetworkingTests/DownloadIntegrationTests.swift
+++ b/Tests/NetworkingTests/DownloadIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 // @MainActor so the local `NSCache` (non-Sendable) used across the `downloadImage` await stays on
@@ -16,10 +17,10 @@ class DownloadIntegrationTests: XCTestCase {
 
         let result: Result<Image, NetworkingError> = await networking.downloadImage(path)
         switch result {
-        case let .success(image):
+        case .success(let image):
             let pigImage = Image.find(named: "pig.png", inBundle: .module)
             XCTAssertEqual(pigImage.pngData(), image.pngData())
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -33,11 +34,11 @@ class DownloadIntegrationTests: XCTestCase {
 
         let result: Result<ImageResponse, NetworkingError> = await networking.downloadImage(path)
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.statusCode, 200)
             let pigImage = Image.find(named: "pig.png", inBundle: .module)
             XCTAssertEqual(pigImage.pngData(), response.image.pngData())
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -80,10 +81,13 @@ class DownloadIntegrationTests: XCTestCase {
         case .success:
             let destinationURL = try networking.destinationURL(for: path)
             let absoluteString = destinationURL.absoluteString
-            guard let image = networking.cache.object(forKey: absoluteString as AnyObject) as? Image else { XCTFail(); return }
+            guard let image = networking.cache.object(forKey: absoluteString as AnyObject) as? Image else {
+                XCTFail()
+                return
+            }
             let pigImage = Image.find(named: "pig.png", inBundle: .module)
             XCTAssertEqual(pigImage.pngData(), image.pngData())
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -100,10 +104,13 @@ class DownloadIntegrationTests: XCTestCase {
         case .success:
             let destinationURL = try networking.destinationURL(for: path, cacheName: cacheName)
             let absoluteString = destinationURL.absoluteString
-            guard let image = networking.cache.object(forKey: absoluteString as AnyObject) as? Image else { XCTFail(); return }
+            guard let image = networking.cache.object(forKey: absoluteString as AnyObject) as? Image else {
+                XCTFail()
+                return
+            }
             let pigImage = Image.find(named: "pig.png", inBundle: .module)
             XCTAssertEqual(pigImage.pngData(), image.pngData())
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -118,7 +125,7 @@ class DownloadIntegrationTests: XCTestCase {
             let image = try networking.imageFromCache(path)
             let pigImage = Image.find(named: "pig.png", inBundle: .module)
             XCTAssertEqual(pigImage.pngData(), image?.pngData())
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -144,10 +151,13 @@ class DownloadIntegrationTests: XCTestCase {
             let destinationURL = try networking.destinationURL(for: path)
             let absoluteString = destinationURL.absoluteString
             networking.cache.removeObject(forKey: absoluteString as AnyObject)
-            guard let image = try networking.imageFromCache(path) else { XCTFail(); return }
+            guard let image = try networking.imageFromCache(path) else {
+                XCTFail()
+                return
+            }
             let pigImage = Image.find(named: "pig.png", inBundle: .module)
             XCTAssertEqual(pigImage.pngData(), image.pngData())
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -163,10 +173,13 @@ class DownloadIntegrationTests: XCTestCase {
             let destinationURL = try networking.destinationURL(for: path, cacheName: cacheName)
             let absoluteString = destinationURL.absoluteString
             networking.cache.removeObject(forKey: absoluteString as AnyObject)
-            guard let image = try networking.imageFromCache(path, cacheName: cacheName) else { XCTFail(); return }
+            guard let image = try networking.imageFromCache(path, cacheName: cacheName) else {
+                XCTFail()
+                return
+            }
             let pigImage = Image.find(named: "pig.png", inBundle: .module)
             XCTAssertEqual(pigImage.pngData(), image.pngData())
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -184,7 +197,7 @@ class DownloadIntegrationTests: XCTestCase {
             try Helper.removeFileIfNeeded(networking, path: path)
             let image = try networking.imageFromCache(path)
             XCTAssertNil(image)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -195,9 +208,9 @@ class DownloadIntegrationTests: XCTestCase {
         try Helper.removeFileIfNeeded(networking, path: path)
         let result: Result<Data, NetworkingError> = await networking.downloadData(path)
         switch result {
-        case let .success(data):
+        case .success(let data):
             XCTAssertEqual(data.count, 8090)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -209,10 +222,10 @@ class DownloadIntegrationTests: XCTestCase {
         try Helper.removeFileIfNeeded(networking, path: path)
         let result: Result<DataResponse, NetworkingError> = await networking.downloadData(path)
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.statusCode, 200)
             XCTAssertEqual(response.data.count, 8090)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -224,13 +237,13 @@ class DownloadIntegrationTests: XCTestCase {
 
         let result: Result<Data, NetworkingError> = await networking.downloadData(path)
         switch result {
-        case let .success(data):
+        case .success(let data):
             if let cacheData = try networking.dataFromCache(path) {
                 XCTAssert(data == cacheData)
             } else {
                 XCTFail()
             }
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }

--- a/Tests/NetworkingTests/DownloadInterceptorIntegrationTests.swift
+++ b/Tests/NetworkingTests/DownloadInterceptorIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 // Downloads should run through the same interceptor chain as the verbs, so retry/auth-refresh apply to
@@ -14,7 +15,9 @@ final class DownloadInterceptorIntegrationTests: XCTestCase {
 
     private struct CountingPassthroughInterceptor: HTTPInterceptor {
         let counter: Counter
-        func intercept(_ request: URLRequest, next: @Sendable (URLRequest) async throws -> HTTPExchange) async throws -> HTTPExchange {
+        func intercept(_ request: URLRequest, next: @Sendable (URLRequest) async throws -> HTTPExchange) async throws
+            -> HTTPExchange
+        {
             await counter.tick()
             return try await next(request)
         }
@@ -27,7 +30,7 @@ final class DownloadInterceptorIntegrationTests: XCTestCase {
 
         let result: Result<Data, NetworkingError> = await networking.downloadData("/bytes/16", cachingLevel: .none)
 
-        if case let .failure(error) = result { XCTFail("expected the download to succeed, got \(error)") }
+        if case .failure(let error) = result { XCTFail("expected the download to succeed, got \(error)") }
         let count = await counter.count
         XCTAssertGreaterThanOrEqual(count, 1, "a download must pass through the interceptor chain")
     }

--- a/Tests/NetworkingTests/EncodableFormQueryIntegrationTests.swift
+++ b/Tests/NetworkingTests/EncodableFormQueryIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 private struct SearchParams: Encodable {
@@ -13,9 +14,10 @@ final class EncodableFormQueryIntegrationTests: XCTestCase {
 
     func testPOSTFormFromEncodableModel() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.post("/post", form: SearchParams(term: "swift & co", page: 2, exact: true))
+        let result: Result<JSONResponse, NetworkingError> = await networking.post(
+            "/post", form: SearchParams(term: "swift & co", page: 2, exact: true))
         switch result {
-        case let .success(response):
+        case .success(let response):
             let form = httpbinEchoedMap(response, "form")
             // Scalars must stringify correctly (bool -> "true", not NSNumber's "1") and special chars must survive.
             XCTAssertEqual(form["term"], "swift & co")
@@ -23,34 +25,36 @@ final class EncodableFormQueryIntegrationTests: XCTestCase {
             XCTAssertEqual(form["exact"], "true")
             let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(headers["Content-Type"], "application/x-www-form-urlencoded")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
 
     func testGETQueryFromEncodableModel() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.get("/get", query: SearchParams(term: "swift", page: 2, exact: false))
+        let result: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get", query: SearchParams(term: "swift", page: 2, exact: false))
         switch result {
-        case let .success(response):
+        case .success(let response):
             let args = httpbinEchoedMap(response, "args")
             XCTAssertEqual(args["term"], "swift")
             XCTAssertEqual(args["page"], "2")
             XCTAssertEqual(args["exact"], "false")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
 
     func testDELETEQueryFromEncodableModel() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.delete("/delete", query: SearchParams(term: "swift", page: 5, exact: true))
+        let result: Result<JSONResponse, NetworkingError> = await networking.delete(
+            "/delete", query: SearchParams(term: "swift", page: 5, exact: true))
         switch result {
-        case let .success(response):
+        case .success(let response):
             let args = httpbinEchoedMap(response, "args")
             XCTAssertEqual(args["page"], "5")
             XCTAssertEqual(args["exact"], "true")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }

--- a/Tests/NetworkingTests/ErrorModelIntegrationTests.swift
+++ b/Tests/NetworkingTests/ErrorModelIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 final class ErrorModelIntegrationTests: XCTestCase {
@@ -10,14 +11,14 @@ final class ErrorModelIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
 
         let serverResult: Result<Data, NetworkingError> = await networking.get("/status/503")
-        guard case let .failure(serverError) = serverResult, case .http = serverError else {
+        guard case .failure(let serverError) = serverResult, case .http = serverError else {
             return XCTFail("expected an HTTP error for 503")
         }
         XCTAssertTrue(serverError.isRetryable, "503 should be retryable")
         XCTAssertEqual(serverError.statusCode, 503)
 
         let clientResult: Result<Data, NetworkingError> = await networking.get("/status/404")
-        guard case let .failure(clientError) = clientResult, case .http = clientError else {
+        guard case .failure(let clientError) = clientResult, case .http = clientError else {
             return XCTFail("expected an HTTP error for 404")
         }
         XCTAssertFalse(clientError.isRetryable, "404 should not be retryable")
@@ -27,7 +28,7 @@ final class ErrorModelIntegrationTests: XCTestCase {
     func testTransportErrorIsRetryable() async throws {
         let networking = Networking(baseURL: "http://127.0.0.1:1")
         let result: Result<Data, NetworkingError> = await networking.get("/anything")
-        guard case let .failure(error) = result, case let .transport(urlError) = error else {
+        guard case .failure(let error) = result, case .transport(let urlError) = error else {
             return XCTFail("expected a transport error, got \(result)")
         }
         XCTAssertTrue(error.isRetryable, "a connection failure should be retryable")
@@ -37,10 +38,10 @@ final class ErrorModelIntegrationTests: XCTestCase {
     // A 2xx whose body doesn't match the requested type surfaces as .decoding, with the DecodingError and
     // response metadata preserved — and is not retryable.
     func testDecodingErrorCarriesMetadata() async throws {
-        struct Mismatch: Decodable { let args: Int } // httpbin's /get returns `args` as an object, not an Int.
+        struct Mismatch: Decodable { let args: Int }  // httpbin's /get returns `args` as an object, not an Int.
         let networking = Networking(baseURL: baseURL)
         let result: Result<Mismatch, NetworkingError> = await networking.get("/get")
-        guard case let .failure(error) = result, case let .decoding(_, metadata) = error else {
+        guard case .failure(let error) = result, case .decoding(_, let metadata) = error else {
             return XCTFail("expected a decoding error, got \(result)")
         }
         XCTAssertEqual(metadata.statusCode, 200)
@@ -50,10 +51,10 @@ final class ErrorModelIntegrationTests: XCTestCase {
 
     // A body that can't be JSON-encoded is a caller-side bug: .invalidRequest, never sent.
     func testUnencodableBodyIsInvalidRequest() async throws {
-        struct Unencodable: Encodable { let value = Double.infinity } // JSONEncoder throws by default.
+        struct Unencodable: Encodable { let value = Double.infinity }  // JSONEncoder throws by default.
         let networking = Networking(baseURL: baseURL)
         let result: Result<Data, NetworkingError> = await networking.post("/post", body: Unencodable())
-        guard case let .failure(error) = result, case let .invalidRequest(reason) = error else {
+        guard case .failure(let error) = result, case .invalidRequest(let reason) = error else {
             return XCTFail("expected an invalid-request error, got \(result)")
         }
         guard case .bodyEncodingFailed = reason else {

--- a/Tests/NetworkingTests/EventStreamIntegrationTests.swift
+++ b/Tests/NetworkingTests/EventStreamIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 final class EventStreamIntegrationTests: XCTestCase {
@@ -7,7 +8,7 @@ final class EventStreamIntegrationTests: XCTestCase {
 
     func testEventsStreamDeliversStartedAndCompleted() async throws {
         let networking = Networking(baseURL: baseURL)
-        let stream = await networking.events()   // registered before the request, so it buffers the events
+        let stream = await networking.events()  // registered before the request, so it buffers the events
 
         let _: Result<JSONResponse, NetworkingError> = await networking.get("/get")
 
@@ -19,10 +20,10 @@ final class EventStreamIntegrationTests: XCTestCase {
         }
 
         XCTAssertEqual(collected.count, eventsPerRequest)
-        guard case .started = collected.first, case let .completed(_, outcome, _, _) = collected.last else {
+        guard case .started = collected.first, case .completed(_, let outcome, _, _) = collected.last else {
             return XCTFail("expected .started then .completed, got \(collected)")
         }
-        guard case let .success(statusCode, _) = outcome else {
+        guard case .success(let statusCode, _) = outcome else {
             return XCTFail("expected a success outcome, got \(outcome)")
         }
         XCTAssertEqual(statusCode, 200)

--- a/Tests/NetworkingTests/FakeRequestTests.swift
+++ b/Tests/NetworkingTests/FakeRequestTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class FakeRequestTests: XCTestCase {
@@ -8,7 +9,7 @@ class FakeRequestTests: XCTestCase {
     // Decodes a fake request's JSON payload back into a dictionary so `find`'s template
     // substitution can be asserted against the typed `.data` payload.
     private func decodedDictionary(_ request: FakeRequest?) -> NSDictionary? {
-        guard case let .data(data)? = request?.payload else { return nil }
+        guard case .data(let data)? = request?.payload else { return nil }
         return (try? JSONSerialization.jsonObject(with: data)) as? NSDictionary
     }
 
@@ -52,7 +53,9 @@ class FakeRequestTests: XCTestCase {
         let json = [
             "name": "Name {userID}"
         ]
-        let request = FakeRequest(payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil, statusCode: 200, delay: 0)
+        let request = FakeRequest(
+            payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil,
+            statusCode: 200, delay: 0)
         let existingRequests = [Networking.RequestType.get: ["/users/{userID}": request]]
         let result = try FakeRequest.find(ofType: .get, forPath: "/users/10", in: existingRequests)
 
@@ -67,7 +70,9 @@ class FakeRequestTests: XCTestCase {
         let json = [
             "name": "Name {userID}"
         ]
-        let request = FakeRequest(payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil, statusCode: 200, delay: 0)
+        let request = FakeRequest(
+            payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil,
+            statusCode: 200, delay: 0)
         let existingRequests = [
             Networking.RequestType.get: [
                 "/users/ados": request,
@@ -75,7 +80,7 @@ class FakeRequestTests: XCTestCase {
                 "/users/cedos": request,
                 "/users/tedos": request,
                 "/users/melos": request,
-                "/users/{userID}": request
+                "/users/{userID}": request,
             ]
         ]
         let result = try FakeRequest.find(ofType: .get, forPath: "/users/10", in: existingRequests)
@@ -90,15 +95,17 @@ class FakeRequestTests: XCTestCase {
     func testTwoLevelFind() throws {
         let json = [
             "user": "User {userID}",
-            "company": "Company {companyID}"
+            "company": "Company {companyID}",
         ]
-        let request = FakeRequest(payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil, statusCode: 200, delay: 0)
+        let request = FakeRequest(
+            payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil,
+            statusCode: 200, delay: 0)
         let existingRequests = [Networking.RequestType.get: ["/users/{userID}/companies/{companyID}": request]]
         let result = try FakeRequest.find(ofType: .get, forPath: "/users/10/companies/20", in: existingRequests)
 
         let expected = [
             "user": "User 10",
-            "company": "Company 20"
+            "company": "Company 20",
         ]
 
         XCTAssertEqual(decodedDictionary(result), expected as NSDictionary)
@@ -108,25 +115,30 @@ class FakeRequestTests: XCTestCase {
         let json = [
             "user": "User {userID}",
             "company": "Company {companyID}",
-            "product": "Product {productID}"
+            "product": "Product {productID}",
         ]
-        let request = FakeRequest(payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil, statusCode: 200, delay: 0)
-        let existingRequests = [Networking.RequestType.get: [
-            "/users/{userID}/companies/{companyID}/products/a": request,
-            "/users/{userID}/companies/{companyID}/products/b": request,
-            "/users/{userID}/companies/{companyID}/products/c": request,
-            "/users/{userID}/companies/{companyID}/products/d": request,
-            "/users/{userID}/companies/{companyID}/products/{productID}": request,
-            "/users/{userID}/companies/{companyID}/products/e": request,
-            "/users/{userID}/companies/{companyID}/products/f": request,
-            "/users/{userID}/companies/{companyID}/products/g": request,
-        ]]
-        let result = try FakeRequest.find(ofType: .get, forPath: "/users/10/companies/20/products/30", in: existingRequests)
+        let request = FakeRequest(
+            payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil,
+            statusCode: 200, delay: 0)
+        let existingRequests = [
+            Networking.RequestType.get: [
+                "/users/{userID}/companies/{companyID}/products/a": request,
+                "/users/{userID}/companies/{companyID}/products/b": request,
+                "/users/{userID}/companies/{companyID}/products/c": request,
+                "/users/{userID}/companies/{companyID}/products/d": request,
+                "/users/{userID}/companies/{companyID}/products/{productID}": request,
+                "/users/{userID}/companies/{companyID}/products/e": request,
+                "/users/{userID}/companies/{companyID}/products/f": request,
+                "/users/{userID}/companies/{companyID}/products/g": request,
+            ]
+        ]
+        let result = try FakeRequest.find(
+            ofType: .get, forPath: "/users/10/companies/20/products/30", in: existingRequests)
 
         let expected = [
             "user": "User 10",
             "company": "Company 20",
-            "product": "Product 30"
+            "product": "Product 30",
         ]
 
         XCTAssertEqual(decodedDictionary(result), expected as NSDictionary)
@@ -146,9 +158,20 @@ class FakeRequestTests: XCTestCase {
             "resource10": "Resource {resourceID10}",
         ]
 
-        let request = FakeRequest(payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil, statusCode: 200, delay: 0)
-        let existingRequests = [Networking.RequestType.get: ["resource1/{resourceID1}/resource2/{resourceID2}/resource3/{resourceID3}/resource4/{resourceID4}/resource5/{resourceID5}/resource6/{resourceID6}/resource7/{resourceID7}/resource8/{resourceID8}/resource9/{resourceID9}/resource10/{resourceID10}": request]]
-        let result = try FakeRequest.find(ofType: .get, forPath: "resource1/1/resource2/2/resource3/3/resource4/4/resource5/5/resource6/6/resource7/7/resource8/8/resource9/9/resource10/10", in: existingRequests)
+        let request = FakeRequest(
+            payload: .data(try JSONSerialization.data(withJSONObject: json)), responseType: .json, headerFields: nil,
+            statusCode: 200, delay: 0)
+        let existingRequests = [
+            Networking.RequestType.get: [
+                "resource1/{resourceID1}/resource2/{resourceID2}/resource3/{resourceID3}/resource4/{resourceID4}/resource5/{resourceID5}/resource6/{resourceID6}/resource7/{resourceID7}/resource8/{resourceID8}/resource9/{resourceID9}/resource10/{resourceID10}":
+                    request
+            ]
+        ]
+        let result = try FakeRequest.find(
+            ofType: .get,
+            forPath:
+                "resource1/1/resource2/2/resource3/3/resource4/4/resource5/5/resource6/6/resource7/7/resource8/8/resource9/9/resource10/10",
+            in: existingRequests)
         let expected = [
             "resource1": "Resource 1",
             "resource2": "Resource 2",
@@ -160,7 +183,7 @@ class FakeRequestTests: XCTestCase {
             "resource8": "Resource 8",
             "resource9": "Resource 9",
             "resource10": "Resource 10",
-            ]
+        ]
         XCTAssertEqual(decodedDictionary(result), expected as NSDictionary)
     }
 }
@@ -174,9 +197,9 @@ extension FakeRequestTests {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/stories")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "name"), "Elvis")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -194,9 +217,9 @@ extension FakeRequestTests {
         XCTAssertGreaterThanOrEqual(elapsedTime1, delay, "The delay was not correctly applied")
 
         switch firstResult {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "name"), "Elvis")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -210,8 +233,8 @@ extension FakeRequestTests {
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 401)
@@ -229,8 +252,8 @@ extension FakeRequestTests {
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 401)
@@ -245,12 +268,13 @@ extension FakeRequestTests {
         await networking.fakeGET("/big-error", response: ["error": longMessage], statusCode: 400)
 
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/big-error")
-        guard case let .failure(.http(httpError)) = result else {
+        guard case .failure(.http(let httpError)) = result else {
             return XCTFail("expected an HTTP error, got \(result)")
         }
         XCTAssertGreaterThan(httpError.metadata.body.count, 512)
         XCTAssertEqual(try httpError.metadata.decode(ServerError.self).error, longMessage)
-        XCTAssertEqual(httpError.metadata.bodySnippet?.hasSuffix("… (truncated)"), true, "the snippet stays a log excerpt")
+        XCTAssertEqual(
+            httpError.metadata.bodySnippet?.hasSuffix("… (truncated)"), true, "the snippet stays a log excerpt")
     }
 
     func testFakeGETUsingFile() async throws {
@@ -260,9 +284,9 @@ extension FakeRequestTests {
 
         let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.get("/entries")
         switch result {
-        case let .success(entries):
+        case .success(let entries):
             XCTAssertEqual(entries.first?.string(for: "title"), "Entry 1")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -283,17 +307,17 @@ extension FakeRequestTests {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/users/10")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "name"), "Name 10")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
 
         let result2: Result<JSONResponse, NetworkingError> = await networking.get("/users/20")
         switch result2 {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "name"), "Name 20")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -305,9 +329,9 @@ extension FakeRequestTests {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/story")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -320,11 +344,12 @@ extension FakeRequestTests {
 
         await networking.fakePOST("/story", response: [["name": "Elvis"]])
 
-        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.post("/story", body: ["username": "jameson", "password": "secret"])
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.post(
+            "/story", body: ["username": "jameson", "password": "secret"])
         switch result {
-        case let .success(stories):
+        case .success(let stories):
             XCTAssertEqual(stories.first?.string(for: "name"), "Elvis")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -338,8 +363,8 @@ extension FakeRequestTests {
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 401)
@@ -353,9 +378,9 @@ extension FakeRequestTests {
 
         let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.post("/entries")
         switch result {
-        case let .success(entries):
+        case .success(let entries):
             XCTAssertEqual(entries.first?.string(for: "title"), "Entry 1")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -367,9 +392,9 @@ extension FakeRequestTests {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/story")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -377,22 +402,22 @@ extension FakeRequestTests {
     func testFakePOSTMultiple() async throws {
         let networking = Networking(baseURL: baseURL)
 
-        await networking.fakeGET("/g/1/1", response: ["id":"2"])
-        await networking.fakeGET("/g/2/2", response: ["id":"2"])
-        await networking.fakePOST("/g/1/e", response: ["id":"2"])
-        await networking.fakePOST("/g/1/b", response: ["id":"5"])
+        await networking.fakeGET("/g/1/1", response: ["id": "2"])
+        await networking.fakeGET("/g/2/2", response: ["id": "2"])
+        await networking.fakePOST("/g/1/e", response: ["id": "2"])
+        await networking.fakePOST("/g/1/b", response: ["id": "5"])
         await networking.fakePOST("/g/5/f")
-        await networking.fakePUT("/g/2/2", response: ["id":"2"])
-        await networking.fakePOST("/g/x/o", response: ["id":"3"])
-        await networking.fakePOST("/g/1/b", response: ["id":"4"])
+        await networking.fakePUT("/g/2/2", response: ["id": "2"])
+        await networking.fakePOST("/g/x/o", response: ["id": "3"])
+        await networking.fakePOST("/g/1/b", response: ["id": "4"])
         await networking.fakeDELETE("/g/2/2")
-        await networking.fakePOST("/g/1/b", response: ["id":"1"])
+        await networking.fakePOST("/g/1/b", response: ["id": "1"])
 
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/g/1/b", body: ["ignored": true])
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "id"), "1")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -405,11 +430,12 @@ extension FakeRequestTests {
 
         await networking.fakePUT("/story", response: [["name": "Elvis"]])
 
-        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.put("/story", body: ["username": "jameson", "password": "secret"])
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.put(
+            "/story", body: ["username": "jameson", "password": "secret"])
         switch result {
-        case let .success(stories):
+        case .success(let stories):
             XCTAssertEqual(stories.first?.string(for: "name"), "Elvis")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -423,8 +449,8 @@ extension FakeRequestTests {
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 401)
@@ -438,9 +464,9 @@ extension FakeRequestTests {
 
         let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.put("/entries")
         switch result {
-        case let .success(entries):
+        case .success(let entries):
             XCTAssertEqual(entries.first?.string(for: "title"), "Entry 1")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -452,9 +478,9 @@ extension FakeRequestTests {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.put("/story")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -467,11 +493,12 @@ extension FakeRequestTests {
 
         await networking.fakePATCH("/story", response: [["name": "Elvis"]])
 
-        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.patch("/story", body: ["username": "jameson", "password": "secret"])
+        let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.patch(
+            "/story", body: ["username": "jameson", "password": "secret"])
         switch result {
-        case let .success(stories):
+        case .success(let stories):
             XCTAssertEqual(stories.first?.string(for: "name"), "Elvis")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -485,8 +512,8 @@ extension FakeRequestTests {
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 401)
@@ -500,9 +527,9 @@ extension FakeRequestTests {
 
         let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.patch("/entries")
         switch result {
-        case let .success(entries):
+        case .success(let entries):
             XCTAssertEqual(entries.first?.string(for: "title"), "Entry 1")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -514,9 +541,9 @@ extension FakeRequestTests {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.patch("/story")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -531,9 +558,9 @@ extension FakeRequestTests {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.delete("/stories")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "name"), "Elvis")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -555,9 +582,9 @@ extension FakeRequestTests {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.delete("/a/1/b/5")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.statusCode, 200)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -571,8 +598,8 @@ extension FakeRequestTests {
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 401)
@@ -586,9 +613,9 @@ extension FakeRequestTests {
 
         let result: Result<[[String: AnyCodable]], NetworkingError> = await networking.delete("/entries")
         switch result {
-        case let .success(entries):
+        case .success(let entries):
             XCTAssertEqual(entries.first?.string(for: "title"), "Entry 1")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -600,9 +627,9 @@ extension FakeRequestTests {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.delete("/story")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -616,9 +643,9 @@ extension FakeRequestTests {
         await networking.fakeImageDownload("/image/png", image: pigImage)
         let result: Result<Image, NetworkingError> = await networking.downloadImage("/image/png")
         switch result {
-        case let .success(image):
+        case .success(let image):
             XCTAssertEqual(pigImage.pngData(), image.pngData())
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -637,9 +664,9 @@ extension FakeRequestTests {
         XCTAssertGreaterThanOrEqual(elapsedTime, delay, "The delay was not correctly applied")
 
         switch result {
-        case let .success(image):
+        case .success(let image):
             XCTAssertEqual(pigImage.pngData(), image.pngData())
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -652,8 +679,8 @@ extension FakeRequestTests {
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 401)
@@ -667,10 +694,10 @@ extension FakeRequestTests {
         await networking.fakeImageDownload("/image/png", image: pigImage, headerFields: ["uid": "12345678"])
         let result: Result<ImageResponse, NetworkingError> = await networking.downloadImage("/image/png")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(pigImage.pngData(), response.image.pngData())
             XCTAssertEqual(response.headers.string(for: "uid"), "12345678")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -678,21 +705,25 @@ extension FakeRequestTests {
     func testNewPostWithFakeHeaders() async {
         let networking = Networking(baseURL: baseURL)
 
-        await networking.fakePOST("/auth/verify_confirmation_code", response: [
-            "phone_number": "phoneNumber"
-        ], headerFields: [
-            "client": "aClient",
-            "access-token": "anAccessToken",
-            "uid": "aUID",
-            "Authorization": "authorization",
-        ])
+        await networking.fakePOST(
+            "/auth/verify_confirmation_code",
+            response: [
+                "phone_number": "phoneNumber"
+            ],
+            headerFields: [
+                "client": "aClient",
+                "access-token": "anAccessToken",
+                "uid": "aUID",
+                "Authorization": "authorization",
+            ])
 
         let parameters = [
             "phone_number": "phoneNumber",
-            "confirmation_code": "confirmationCode"
+            "confirmation_code": "confirmationCode",
         ]
 
-        let result: Result<JSONResponse, NetworkingError> = await networking.post("/auth/verify_confirmation_code", body: parameters)
+        let result: Result<JSONResponse, NetworkingError> = await networking.post(
+            "/auth/verify_confirmation_code", body: parameters)
         switch result {
         case .success(let response):
             let headers = response.headers
@@ -703,7 +734,7 @@ extension FakeRequestTests {
 
             let body = response.body
             XCTAssertEqual(body.string(for: "phone_number"), "phoneNumber")
-        case .failure (let response):
+        case .failure(let response):
             XCTFail(response.localizedDescription)
         }
     }

--- a/Tests/NetworkingTests/FileLoggingIntegrationTests.swift
+++ b/Tests/NetworkingTests/FileLoggingIntegrationTests.swift
@@ -1,31 +1,37 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 final class FileLoggingIntegrationTests: XCTestCase {
     // The diagnostics file sink lets a CLI / headless / agent run read what happened, since os.Logger
     // isn't visible in stdout. (The NETWORKING_LOG_FILE env var sets the same `logFileURL` at init.)
     func testDiagnosticsAreWrittenToConfiguredFile() async throws {
-        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("networking-\(UUID().uuidString).log")
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(
+            "networking-\(UUID().uuidString).log")
         defer { try? FileManager.default.removeItem(at: url) }
 
         let networking = Networking(baseURL: TestConfig.httpbinBaseURL)
         await networking.setLogFileURL(url)
 
-        let _: Result<JSONResponse, NetworkingError> = await networking.get("/get")          // success — not logged
-        let _: Result<JSONResponse, NetworkingError> = await networking.get("/status/404")   // failure — logged
+        let _: Result<JSONResponse, NetworkingError> = await networking.get("/get")  // success — not logged
+        let _: Result<JSONResponse, NetworkingError> = await networking.get("/status/404")  // failure — logged
 
         let contents = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
         XCTAssertFalse(contents.contains("/get "), "successful requests must not be logged; got:\n\(contents)")
         XCTAssertTrue(contents.contains("✗ GET"), "expected a failure line; got:\n\(contents)")
-        XCTAssertTrue(contents.contains("failed: The server returned status 404"), "expected the failure detail; got:\n\(contents)")
+        XCTAssertTrue(
+            contents.contains("failed: The server returned status 404"),
+            "expected the failure detail; got:\n\(contents)")
     }
 
     // NETWORKING_LOG_FILE resolution: a bare name lands in Caches (sandbox-safe for an app); a path is used as-is.
     func testLogFileEnvValueResolution() {
         let bare = Networking.resolveLogFileURL("networking.log")
         XCTAssertEqual(bare?.lastPathComponent, "networking.log")
-        XCTAssertTrue(bare?.path.contains("Caches") ?? false, "a bare name should resolve under Caches; got \(String(describing: bare?.path))")
+        XCTAssertTrue(
+            bare?.path.contains("Caches") ?? false,
+            "a bare name should resolve under Caches; got \(String(describing: bare?.path))")
 
         XCTAssertEqual(Networking.resolveLogFileURL("/tmp/explicit.log")?.path, "/tmp/explicit.log")
         XCTAssertNil(Networking.resolveLogFileURL(""))

--- a/Tests/NetworkingTests/GETIntegrationTests.swift
+++ b/Tests/NetworkingTests/GETIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class GETIntegrationTests: XCTestCase {
@@ -9,10 +10,10 @@ class GETIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get")
             XCTAssertNil(httpbinEchoedMap(response, "headers")["Content-Type"])
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -21,10 +22,10 @@ class GETIntegrationTests: XCTestCase {
         let networking = Networking()
         let result: Result<JSONResponse, NetworkingError> = await networking.get("\(TestConfig.httpbinBaseURL)/get")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get")
             XCTAssertNil(httpbinEchoedMap(response, "headers")["Content-Type"])
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -33,10 +34,10 @@ class GETIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/get")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get")
             XCTAssertTrue(response.headers.string(for: "Content-Type")?.hasPrefix("application/json") ?? false)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -47,8 +48,8 @@ class GETIntegrationTests: XCTestCase {
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 404)
@@ -60,11 +61,11 @@ class GETIntegrationTests: XCTestCase {
 
         // 2xx succeeds (empty body, so decode as Data).
         let ok: Result<Data, NetworkingError> = await networking.get("/status/200")
-        if case let .failure(error) = ok { XCTFail("200 should succeed, got \(error)") }
+        if case .failure(let error) = ok { XCTFail("200 should succeed, got \(error)") }
 
         // 4xx -> .http carrying the status code, flagged as a client error.
         let clientError: Result<Data, NetworkingError> = await networking.get("/status/404")
-        guard case let .failure(.http(clientHTTPError)) = clientError else {
+        guard case .failure(.http(let clientHTTPError)) = clientError else {
             return XCTFail("expected an HTTP error")
         }
         XCTAssertEqual(clientHTTPError.statusCode, 404)
@@ -72,7 +73,7 @@ class GETIntegrationTests: XCTestCase {
 
         // 5xx -> .http carrying the status code, flagged as a server error.
         let serverError: Result<Data, NetworkingError> = await networking.get("/status/500")
-        guard case let .failure(.http(serverHTTPError)) = serverError else {
+        guard case .failure(.http(let serverHTTPError)) = serverError else {
             return XCTFail("expected a server error")
         }
         XCTAssertEqual(serverHTTPError.statusCode, 500)
@@ -81,33 +82,36 @@ class GETIntegrationTests: XCTestCase {
 
     func testGETWithURLEncodedParameters() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.get("/get", query: [URLQueryItem(name: "count", value: "25")])
+        let result: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get", query: [URLQueryItem(name: "count", value: "25")])
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get?count=25")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
 
     func testGETWithURLEncodedParametersWithExistingQuery() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.get("/get?accountId=123", query: [URLQueryItem(name: "userId", value: "5")])
+        let result: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get?accountId=123", query: [URLQueryItem(name: "userId", value: "5")])
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get?accountId=123&userId=5")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
 
     func testGETWithURLEncodedParametersWithPercentEncoding() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.get("/get", query: [URLQueryItem(name: "name", value: "Elvis Nuñez")])
+        let result: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get", query: [URLQueryItem(name: "name", value: "Elvis Nuñez")])
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get?name=Elvis%20Nu%C3%B1ez")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -121,7 +125,7 @@ class GETIntegrationTests: XCTestCase {
         let first: Result<JSONResponse, NetworkingError> = await networking.get("/uuid", cachingLevel: .memory)
         let second: Result<JSONResponse, NetworkingError> = await networking.get("/uuid", cachingLevel: .memory)
 
-        guard case let .success(firstResponse) = first, case let .success(secondResponse) = second else {
+        guard case .success(let firstResponse) = first, case .success(let secondResponse) = second else {
             return XCTFail("expected both requests to succeed")
         }
         XCTAssertEqual(firstResponse.statusCode, 200)
@@ -142,9 +146,10 @@ class GETIntegrationTests: XCTestCase {
 
         let primed: Result<JSONResponse, NetworkingError> = await networking.get("/uuid", cachingLevel: .memoryAndFile)
         let _: Result<JSONResponse, NetworkingError> = await networking.get("/uuid", cachingLevel: .none)
-        let afterwards: Result<JSONResponse, NetworkingError> = await networking.get("/uuid", cachingLevel: .memoryAndFile)
+        let afterwards: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/uuid", cachingLevel: .memoryAndFile)
 
-        guard case let .success(primedResponse) = primed, case let .success(afterwardsResponse) = afterwards else {
+        guard case .success(let primedResponse) = primed, case .success(let afterwardsResponse) = afterwards else {
             return XCTFail("expected both cached requests to succeed")
         }
         XCTAssertNotNil(primedResponse.body.string(for: "uuid"))
@@ -160,10 +165,12 @@ class GETIntegrationTests: XCTestCase {
         let cache = NSCache<AnyObject, AnyObject>()
         let networking = Networking(baseURL: baseURL, cache: cache)
 
-        let first: Result<JSONResponse, NetworkingError> = await networking.get("/get", query: [URLQueryItem(name: "value", value: "1")], cachingLevel: .memory)
-        let second: Result<JSONResponse, NetworkingError> = await networking.get("/get", query: [URLQueryItem(name: "value", value: "2")], cachingLevel: .memory)
+        let first: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get", query: [URLQueryItem(name: "value", value: "1")], cachingLevel: .memory)
+        let second: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get", query: [URLQueryItem(name: "value", value: "2")], cachingLevel: .memory)
 
-        guard case let .success(firstResponse) = first, case let .success(secondResponse) = second else {
+        guard case .success(let firstResponse) = first, case .success(let secondResponse) = second else {
             return XCTFail("expected both requests to succeed")
         }
         XCTAssertEqual(firstResponse.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/get?value=1")
@@ -177,15 +184,20 @@ class GETIntegrationTests: XCTestCase {
         let cache = NSCache<AnyObject, AnyObject>()
         let networking = Networking(baseURL: baseURL, cache: cache)
 
-        let _: Result<JSONResponse, NetworkingError> = await networking.get("/get", query: [URLQueryItem(name: "a", value: "1&b=2")], cachingLevel: .memory)
-        let second: Result<JSONResponse, NetworkingError> = await networking.get("/get", query: [URLQueryItem(name: "a", value: "1"), URLQueryItem(name: "b", value: "2")], cachingLevel: .memory)
+        let _: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get", query: [URLQueryItem(name: "a", value: "1&b=2")], cachingLevel: .memory)
+        let second: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get", query: [URLQueryItem(name: "a", value: "1"), URLQueryItem(name: "b", value: "2")],
+            cachingLevel: .memory)
 
-        guard case let .success(secondResponse) = second else {
+        guard case .success(let secondResponse) = second else {
             return XCTFail("expected the second request to succeed")
         }
         let url = secondResponse.body.string(for: "url") ?? ""
         XCTAssertFalse(url.contains("%26"), "the second request must not be served the first request's cached body")
-        XCTAssertTrue(url.contains("a=1") && url.contains("b=2"), "the second request must reflect its own parameters, got: \(url)")
+        XCTAssertTrue(
+            url.contains("a=1") && url.contains("b=2"),
+            "the second request must reflect its own parameters, got: \(url)")
     }
 
     // Full-URL GETs to different hosts but the same path must not collide. A key built from only
@@ -210,11 +222,13 @@ class GETIntegrationTests: XCTestCase {
         let _: Result<JSONResponse, NetworkingError> = await networking.get("\(base)/get", cachingLevel: .memory)
         let second: Result<JSONResponse, NetworkingError> = await networking.get("\(alias)/get", cachingLevel: .memory)
 
-        guard case let .success(secondResponse) = second else {
+        guard case .success(let secondResponse) = second else {
             return XCTFail("expected the second request to succeed")
         }
         let url = secondResponse.body.string(for: "url") ?? ""
-        XCTAssertTrue(url.contains(aliasHost), "a request to a different host must not receive the first host's cached body, got: \(url)")
+        XCTAssertTrue(
+            url.contains(aliasHost),
+            "a request to a different host must not receive the first host's cached body, got: \(url)")
     }
 
     // A cache hit must carry the original response's status code and headers, not fabricated ones.
@@ -225,7 +239,7 @@ class GETIntegrationTests: XCTestCase {
         let _: Result<JSONResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memory)
         let cached: Result<JSONResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memory)
 
-        guard case let .success(response) = cached else {
+        guard case .success(let response) = cached else {
             return XCTFail("expected the cached request to succeed")
         }
         XCTAssertEqual(response.statusCode, 200)

--- a/Tests/NetworkingTests/GETTests.swift
+++ b/Tests/NetworkingTests/GETTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 struct Friend: Decodable {
@@ -16,9 +17,9 @@ class GETTests: XCTestCase {
         await networking.fakeGET("/get", response: ["key": "value1"])
         let firstResult: Result<JSONResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memory)
         switch firstResult {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "key"), "value1")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
 
@@ -26,9 +27,9 @@ class GETTests: XCTestCase {
 
         let secondResult: Result<JSONResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memory)
         switch secondResult {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "key"), "value2")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -37,20 +38,22 @@ class GETTests: XCTestCase {
         let cache = NSCache<AnyObject, AnyObject>()
         let networking = Networking(baseURL: baseURL, configuration: .default, cache: cache)
         await networking.fakeGET("/get", response: ["key": "value1"])
-        let firstResult: Result<JSONResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memoryAndFile)
+        let firstResult: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get", cachingLevel: .memoryAndFile)
         switch firstResult {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "key"), "value1")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
 
         await networking.fakeGET("/get", response: ["key": "value2"])
-        let secondResult: Result<JSONResponse, NetworkingError> = await networking.get("/get", cachingLevel: .memoryAndFile)
+        let secondResult: Result<JSONResponse, NetworkingError> = await networking.get(
+            "/get", cachingLevel: .memoryAndFile)
         switch secondResult {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "key"), "value2")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -61,18 +64,18 @@ class GETTests: XCTestCase {
         await networking.fakeGET("/get", response: ["key": "value1"])
         let firstResult: Result<JSONResponse, NetworkingError> = await networking.get("/get", cachingLevel: .none)
         switch firstResult {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "key"), "value1")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
 
         await networking.fakeGET("/get", response: ["key": "value2"])
         let secondResult: Result<JSONResponse, NetworkingError> = await networking.get("/get", cachingLevel: .none)
         switch secondResult {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "key"), "value2")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }

--- a/Tests/NetworkingTests/LogLevelIntegrationTests.swift
+++ b/Tests/NetworkingTests/LogLevelIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 // Built-in logging scope: `.none` logs nothing, `.failures` (default) logs every failure with full
@@ -8,7 +9,8 @@ final class LogLevelIntegrationTests: XCTestCase {
     let baseURL = TestConfig.httpbinBaseURL
 
     private func log(level: Networking.LogLevel, _ body: (Networking) async -> Void) async -> String {
-        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("networking-\(UUID().uuidString).log")
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(
+            "networking-\(UUID().uuidString).log")
         defer { try? FileManager.default.removeItem(at: url) }
         let networking = Networking(baseURL: baseURL)
         await networking.setLogFileURL(url)
@@ -26,11 +28,13 @@ final class LogLevelIntegrationTests: XCTestCase {
 
     func testFailuresLevelLogsFailureWithFullDetail() async {
         let contents = await log(level: .failures) { networking in
-            let _: Result<JSONResponse, NetworkingError> = await networking.post("/status/400", body: ["shape": "wrong"])
+            let _: Result<JSONResponse, NetworkingError> = await networking.post(
+                "/status/400", body: ["shape": "wrong"])
         }
         XCTAssertTrue(contents.contains("✗ POST"), "expected the failure line; got:\n\(contents)")
         XCTAssertTrue(contents.contains("→ Content-Type"), "expected request headers; got:\n\(contents)")
-        XCTAssertTrue(contents.contains("→ body:") && contents.contains("shape"), "expected the request body; got:\n\(contents)")
+        XCTAssertTrue(
+            contents.contains("→ body:") && contents.contains("shape"), "expected the request body; got:\n\(contents)")
         XCTAssertTrue(contents.contains("← Content-Type"), "expected response headers; got:\n\(contents)")
     }
 
@@ -39,7 +43,8 @@ final class LogLevelIntegrationTests: XCTestCase {
             let _: Result<JSONResponse, NetworkingError> = await networking.post("/post", body: ["shape": "right"])
         }
         XCTAssertTrue(contents.contains("✓ POST"), "expected a success line at .all; got:\n\(contents)")
-        XCTAssertTrue(contents.contains("→ body:") && contents.contains("shape"), "expected the request body; got:\n\(contents)")
+        XCTAssertTrue(
+            contents.contains("→ body:") && contents.contains("shape"), "expected the request body; got:\n\(contents)")
         XCTAssertTrue(contents.contains("← body:"), "expected the response body; got:\n\(contents)")
     }
 
@@ -47,7 +52,8 @@ final class LogLevelIntegrationTests: XCTestCase {
     // the line still logs, but the payload and Authorization/Cookie values are replaced with <redacted> so
     // they can't leak to prod logs.
     func testBodiesAndHeadersRedactedWhenEnabled() async {
-        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("networking-\(UUID().uuidString).log")
+        let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(
+            "networking-\(UUID().uuidString).log")
         defer { try? FileManager.default.removeItem(at: url) }
         let networking = Networking(baseURL: baseURL)
         await networking.setLogFileURL(url)
@@ -55,12 +61,14 @@ final class LogLevelIntegrationTests: XCTestCase {
         await networking.setRedactsLogs(true)
         await networking.setAuthorizationHeader(token: "supersecret")
 
-        let _: Result<JSONResponse, NetworkingError> = await networking.post("/status/400", body: ["shape": "secret-value"])
+        let _: Result<JSONResponse, NetworkingError> = await networking.post(
+            "/status/400", body: ["shape": "secret-value"])
 
         let contents = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
         XCTAssertTrue(contents.contains("✗ POST"), "the failure line should still log; got:\n\(contents)")
         XCTAssertTrue(contents.contains("→ body: <redacted>"), "the request body should be redacted; got:\n\(contents)")
-        XCTAssertTrue(contents.contains("→ Authorization: <redacted>"), "the auth header should be redacted; got:\n\(contents)")
+        XCTAssertTrue(
+            contents.contains("→ Authorization: <redacted>"), "the auth header should be redacted; got:\n\(contents)")
         XCTAssertFalse(contents.contains("secret-value"), "the body contents must not leak; got:\n\(contents)")
         XCTAssertFalse(contents.contains("supersecret"), "the auth token must not leak; got:\n\(contents)")
     }
@@ -72,7 +80,9 @@ final class LogLevelIntegrationTests: XCTestCase {
             await networking.setAuthorizationHeader(token: "supersecret")
             let _: Result<JSONResponse, NetworkingError> = await networking.get("/status/401")
         }
-        XCTAssertTrue(contents.contains("→ Authorization: Bearer supersecret"), "debug logs should show the real header; got:\n\(contents)")
+        XCTAssertTrue(
+            contents.contains("→ Authorization: Bearer supersecret"),
+            "debug logs should show the real header; got:\n\(contents)")
     }
 
     func testNoneSilencesEvenFailures() async {

--- a/Tests/NetworkingTests/NetworkingIntegrationTests.swift
+++ b/Tests/NetworkingTests/NetworkingIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class NetworkingIntegrationTests: XCTestCase {
@@ -10,10 +11,10 @@ class NetworkingIntegrationTests: XCTestCase {
         await networking.setAuthorizationHeader(username: "user", password: "passwd")
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/basic-auth/user/passwd")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "user"), "user")
             XCTAssertEqual(response.body.bool(for: "authenticated"), true)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -24,10 +25,10 @@ class NetworkingIntegrationTests: XCTestCase {
         await networking.setAuthorizationHeader(token: token)
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/post")
         switch result {
-        case let .success(response):
+        case .success(let response):
             let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual("Bearer \(token)", headers["Authorization"])
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -37,10 +38,10 @@ class NetworkingIntegrationTests: XCTestCase {
         await networking.setHeaderFields(["HeaderKey": "HeaderValue"])
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/post")
         switch result {
-        case let .success(response):
+        case .success(let response):
             let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual("HeaderValue", headers["Headerkey"])
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }

--- a/Tests/NetworkingTests/NetworkingTests.swift
+++ b/Tests/NetworkingTests/NetworkingTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class NetworkingTests: XCTestCase {
@@ -11,10 +12,10 @@ class NetworkingTests: XCTestCase {
         await networking.setAuthorizationHeader(headerValue: value)
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/post")
         switch result {
-        case let .success(response):
+        case .success(let response):
             let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(value, headers["Authorization"])
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -26,10 +27,10 @@ class NetworkingTests: XCTestCase {
         await networking.setAuthorizationHeader(headerKey: key, headerValue: value)
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/post")
         switch result {
-        case let .success(response):
+        case .success(let response):
             let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(value, headers[key])
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -118,11 +119,14 @@ class NetworkingTests: XCTestCase {
     }
 
     func testSplitBaseURLAndRelativePath() throws {
-        let (baseURL1, relativePath1) = try XCTUnwrap(Networking.splitBaseURLAndRelativePath(for: "https://rescuejuice.com/wp-content/uploads/2015/11/døgnvillburgere.jpg"))
+        let (baseURL1, relativePath1) = try XCTUnwrap(
+            Networking.splitBaseURLAndRelativePath(
+                for: "https://rescuejuice.com/wp-content/uploads/2015/11/døgnvillburgere.jpg"))
         XCTAssertEqual(baseURL1, "https://rescuejuice.com")
         XCTAssertEqual(relativePath1, "/wp-content/uploads/2015/11/døgnvillburgere.jpg")
 
-        let (baseURL2, relativePath2) = try XCTUnwrap(Networking.splitBaseURLAndRelativePath(for: "http://example.com/basic-auth/user/passwd"))
+        let (baseURL2, relativePath2) = try XCTUnwrap(
+            Networking.splitBaseURLAndRelativePath(for: "http://example.com/basic-auth/user/passwd"))
         XCTAssertEqual(baseURL2, "http://example.com")
         XCTAssertEqual(relativePath2, "/basic-auth/user/passwd")
     }

--- a/Tests/NetworkingTests/NewNetworkingIntegrationTests.swift
+++ b/Tests/NetworkingTests/NewNetworkingIntegrationTests.swift
@@ -1,6 +1,7 @@
+import CoreLocation
 import Foundation
 import XCTest
-import CoreLocation
+
 @testable import Networking
 
 class NewNetworkingIntegrationTests: XCTestCase {
@@ -29,7 +30,7 @@ class NewNetworkingIntegrationTests: XCTestCase {
             URLQueryItem(name: "pickup_latitude", value: "\(pickupCoordinate.latitude)"),
             URLQueryItem(name: "pickup_longitude", value: "\(pickupCoordinate.longitude)"),
             URLQueryItem(name: "delivery_latitude", value: "\(deliveryCoordinate.latitude)"),
-            URLQueryItem(name: "delivery_longitude", value: "\(deliveryCoordinate.longitude)")
+            URLQueryItem(name: "delivery_longitude", value: "\(deliveryCoordinate.longitude)"),
         ]
 
         let result: Result<Friend, NetworkingError> = await networking.get("/get", query: query)

--- a/Tests/NetworkingTests/NewNetworkingTests.swift
+++ b/Tests/NetworkingTests/NewNetworkingTests.swift
@@ -1,6 +1,7 @@
+import CoreLocation
 import Foundation
 import XCTest
-import CoreLocation
+
 @testable import Networking
 
 class NewNetworkingTests: XCTestCase {
@@ -23,7 +24,7 @@ class NewNetworkingTests: XCTestCase {
         case .success:
             XCTFail("expected a 422 failure")
         case .failure(let error):
-            guard case let .http(httpError) = error else {
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 422)

--- a/Tests/NetworkingTests/ObservabilityIntegrationTests.swift
+++ b/Tests/NetworkingTests/ObservabilityIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 final class ObservabilityIntegrationTests: XCTestCase {
@@ -13,14 +14,15 @@ final class ObservabilityIntegrationTests: XCTestCase {
 
         let events = await stream.collect(2)
         XCTAssertEqual(events.count, 2, "expected a .started and a .completed event")
-        guard case let .started(startContext) = events.first,
-              case let .completed(endContext, outcome, duration, metrics) = events.last else {
+        guard case .started(let startContext) = events.first,
+            case .completed(let endContext, let outcome, let duration, let metrics) = events.last
+        else {
             return XCTFail("expected .started then .completed, got \(events)")
         }
         XCTAssertEqual(startContext.id, endContext.id, "the two events should share a request id")
         XCTAssertEqual(startContext.method, "GET")
         XCTAssertGreaterThan(duration, .zero)
-        guard case let .success(statusCode, byteCount) = outcome else {
+        guard case .success(let statusCode, let byteCount) = outcome else {
             return XCTFail("expected a success outcome, got \(outcome)")
         }
         XCTAssertEqual(statusCode, 200)
@@ -35,10 +37,10 @@ final class ObservabilityIntegrationTests: XCTestCase {
         let _: Result<Data, NetworkingError> = await networking.get("/status/500")
 
         let events = await stream.collect(2)
-        guard case let .completed(_, outcome, _, _) = events.last else {
+        guard case .completed(_, let outcome, _, _) = events.last else {
             return XCTFail("expected a .completed event, got \(events)")
         }
-        guard case let .failure(error) = outcome, case let .http(httpError) = error else {
+        guard case .failure(let error) = outcome, case .http(let httpError) = error else {
             return XCTFail("expected a failure outcome carrying an HTTP error, got \(outcome)")
         }
         XCTAssertEqual(httpError.statusCode, 500)
@@ -55,7 +57,7 @@ final class ObservabilityIntegrationTests: XCTestCase {
         let _: Result<JSONResponse, NetworkingError> = await networking.get("/get")
 
         let events = await stream.collect(1)
-        guard case let .started(context) = events.first else {
+        guard case .started(let context) = events.first else {
             return XCTFail("expected a .started event, got \(events)")
         }
         XCTAssertEqual(context.headers["Authorization"], "Bearer supersecret", "events() carries the real header value")
@@ -66,7 +68,7 @@ final class ObservabilityIntegrationTests: XCTestCase {
     // A request that fails to encode never reaches the network, but it's still a request attempt — it must
     // emit the same .started/.completed pair so consumers (analytics, activity indicators) don't miss it.
     func testEncodingFailureStillEmitsEvents() async {
-        struct Unencodable: Encodable { let value = Double.infinity } // JSONEncoder throws by default.
+        struct Unencodable: Encodable { let value = Double.infinity }  // JSONEncoder throws by default.
         let networking = Networking(baseURL: baseURL)
         let stream = await networking.events()
 
@@ -74,12 +76,13 @@ final class ObservabilityIntegrationTests: XCTestCase {
 
         let events = await stream.collect(2)
         XCTAssertEqual(events.count, 2, "an encode failure must still emit .started and .completed; got \(events)")
-        guard case let .started(startContext) = events.first,
-              case let .completed(endContext, outcome, _, _) = events.last else {
+        guard case .started(let startContext) = events.first,
+            case .completed(let endContext, let outcome, _, _) = events.last
+        else {
             return XCTFail("expected .started then .completed, got \(events)")
         }
         XCTAssertEqual(startContext.id, endContext.id, "both events should share a request id")
-        guard case let .failure(error) = outcome, case .invalidRequest = error else {
+        guard case .failure(let error) = outcome, case .invalidRequest = error else {
             return XCTFail("expected an .invalidRequest failure outcome, got \(outcome)")
         }
     }

--- a/Tests/NetworkingTests/PATCHIntegrationTests.swift
+++ b/Tests/NetworkingTests/PATCHIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class PATCHIntegrationTests: XCTestCase {
@@ -7,16 +8,17 @@ class PATCHIntegrationTests: XCTestCase {
 
     func testPATCH() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.patch("/patch", body: ["username": "jameson", "password": "secret"])
+        let result: Result<JSONResponse, NetworkingError> = await networking.patch(
+            "/patch", body: ["username": "jameson", "password": "secret"])
         switch result {
-        case let .success(response):
+        case .success(let response):
             let json = httpbinEchoedMap(response, "json")
             XCTAssertEqual(json["username"], "jameson")
             XCTAssertEqual(json["password"], "secret")
 
             let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(headers["Content-Type"], "application/json")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -25,22 +27,23 @@ class PATCHIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let result: Result<JSONResponse, NetworkingError> = await networking.patch("/patch")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/patch")
             XCTAssertTrue(response.headers.string(for: "Content-Type")?.hasPrefix("application/json") ?? false)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
 
     func testPATCHWithIvalidPath() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.patch("/posdddddt", body: ["username": "jameson", "password": "secret"])
+        let result: Result<JSONResponse, NetworkingError> = await networking.patch(
+            "/posdddddt", body: ["username": "jameson", "password": "secret"])
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 404)

--- a/Tests/NetworkingTests/POSTIntegrationTests.swift
+++ b/Tests/NetworkingTests/POSTIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class POSTIntegrationTests: XCTestCase {
@@ -10,9 +11,9 @@ class POSTIntegrationTests: XCTestCase {
         // A bodyless POST carries no Content-Type — it just has to reach the endpoint and succeed.
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/post")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -26,14 +27,15 @@ class POSTIntegrationTests: XCTestCase {
             let bool: Bool
         }
         // Distinct values so an Int/Double/Bool encoding mix-up would actually fail the assertions.
-        let result: Result<PostJSONEcho, NetworkingError> = await networking.post("/post", body: Payload(string: "valueA", int: 20, double: 20.5, bool: false))
+        let result: Result<PostJSONEcho, NetworkingError> = await networking.post(
+            "/post", body: Payload(string: "valueA", int: 20, double: 20.5, bool: false))
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.json.string, "valueA")
             XCTAssertEqual(response.json.int, 20)
             XCTAssertEqual(response.json.double, 20.5)
             XCTAssertEqual(response.json.bool, false)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -42,10 +44,10 @@ class POSTIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/post")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
             XCTAssertTrue(response.headers.string(for: "Content-Type")?.hasPrefix("application/json") ?? false)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -54,9 +56,9 @@ class POSTIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/post")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -72,14 +74,14 @@ class POSTIntegrationTests: XCTestCase {
         ]
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/post", form: parameters)
         switch result {
-        case let .success(response):
+        case .success(let response):
             let form = httpbinEchoedMap(response, "form")
             XCTAssertEqual(form["string"], "B&B")
             XCTAssertEqual(form["int"], "20")
             XCTAssertEqual(form["double"], "20.0")
             XCTAssertEqual(form["bool"], "true")
             XCTAssertEqual(form["date"], "2016-11-02T13:55:28+01:00")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -97,9 +99,10 @@ class POSTIntegrationTests: XCTestCase {
             "double": "20.0",
             "bool": "true",
         ]
-        let result: Result<JSONResponse, NetworkingError> = await networking.post("/post", parts: [part1, part2], fields: fields)
+        let result: Result<JSONResponse, NetworkingError> = await networking.post(
+            "/post", parts: [part1, part2], fields: fields)
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
 
             let headers = httpbinEchoedMap(response, "headers")
@@ -114,7 +117,7 @@ class POSTIntegrationTests: XCTestCase {
             XCTAssertEqual(form["int"], "20")
             XCTAssertEqual(form["double"], "20.0")
             XCTAssertEqual(form["bool"], "true")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -126,7 +129,7 @@ class POSTIntegrationTests: XCTestCase {
         let part1 = FormDataPart(data: item1.data(using: .utf8)!, parameterName: item1, filename: "\(item1).png")
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/post", parts: [part1])
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
 
             let headers = httpbinEchoedMap(response, "headers")
@@ -134,7 +137,7 @@ class POSTIntegrationTests: XCTestCase {
 
             let files = httpbinEchoedMap(response, "files")
             XCTAssertEqual(files[item1], item1)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -146,9 +149,10 @@ class POSTIntegrationTests: XCTestCase {
         let imageData = try Data(contentsOf: imageURL)
         let imagePart = FormDataPart(data: imageData, parameterName: "file", filename: "pig.png")
 
-        let result: Result<JSONResponse, NetworkingError> = await networking.post("/post", parts: [imagePart], fields: ["public_id": "pig"])
+        let result: Result<JSONResponse, NetworkingError> = await networking.post(
+            "/post", parts: [imagePart], fields: ["public_id": "pig"])
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/post")
 
             let headers = httpbinEchoedMap(response, "headers")
@@ -162,7 +166,7 @@ class POSTIntegrationTests: XCTestCase {
 
             let form = httpbinEchoedMap(response, "form")
             XCTAssertEqual(form["public_id"], "pig")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -171,22 +175,23 @@ class POSTIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let result: Result<JSONResponse, NetworkingError> = await networking.post("/status/204")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.statusCode, 204)
             XCTAssertTrue(response.body.isEmpty)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
 
     func testPOSTWithIvalidPath() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.post("/posdddddt", body: ["username": "jameson", "password": "secret"])
+        let result: Result<JSONResponse, NetworkingError> = await networking.post(
+            "/posdddddt", body: ["username": "jameson", "password": "secret"])
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 404)

--- a/Tests/NetworkingTests/PUTIntegrationTests.swift
+++ b/Tests/NetworkingTests/PUTIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class PUTIntegrationTests: XCTestCase {
@@ -7,16 +8,17 @@ class PUTIntegrationTests: XCTestCase {
 
     func testPUT() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.put("/put", body: ["username": "jameson", "password": "secret"])
+        let result: Result<JSONResponse, NetworkingError> = await networking.put(
+            "/put", body: ["username": "jameson", "password": "secret"])
         switch result {
-        case let .success(response):
+        case .success(let response):
             let json = httpbinEchoedMap(response, "json")
             XCTAssertEqual(json["username"], "jameson")
             XCTAssertEqual(json["password"], "secret")
 
             let headers = httpbinEchoedMap(response, "headers")
             XCTAssertEqual(headers["Content-Type"], "application/json")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -25,22 +27,23 @@ class PUTIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let result: Result<JSONResponse, NetworkingError> = await networking.put("/put")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "url"), "\(TestConfig.httpbinBaseURL)/put")
             XCTAssertTrue(response.headers.string(for: "Content-Type")?.hasPrefix("application/json") ?? false)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
 
     func testPUTWithIvalidPath() async throws {
         let networking = Networking(baseURL: baseURL)
-        let result: Result<JSONResponse, NetworkingError> = await networking.put("/posdddddt", body: ["username": "jameson", "password": "secret"])
+        let result: Result<JSONResponse, NetworkingError> = await networking.put(
+            "/posdddddt", body: ["username": "jameson", "password": "secret"])
         switch result {
         case .success:
             XCTFail()
-        case let .failure(error):
-            guard case let .http(httpError) = error else {
+        case .failure(let error):
+            guard case .http(let httpError) = error else {
                 return XCTFail("expected an HTTP error, got \(error)")
             }
             XCTAssertEqual(httpError.statusCode, 404)

--- a/Tests/NetworkingTests/ResponseIntegrationTests.swift
+++ b/Tests/NetworkingTests/ResponseIntegrationTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+
 @testable import Networking
 
 class ResponseIntegrationTests: XCTestCase {
@@ -10,9 +11,9 @@ class ResponseIntegrationTests: XCTestCase {
         await networking.setHeaderFields(["user-agent": expectedUserAgent])
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/user-agent")
         switch result {
-        case let .success(response):
+        case .success(let response):
             XCTAssertEqual(response.body.string(for: "user-agent"), expectedUserAgent)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }

--- a/Tests/NetworkingTests/ResponseValidatorIntegrationTests.swift
+++ b/Tests/NetworkingTests/ResponseValidatorIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 // go-httpbin's /xml returns 200 with application/xml and /json returns 200 with application/json, so a
@@ -24,7 +25,7 @@ final class ResponseValidatorIntegrationTests: XCTestCase {
 
         let result: Result<Data, NetworkingError> = await networking.get("/xml")
 
-        guard case let .failure(.validation(reason, metadata)) = result else {
+        guard case .failure(.validation(let reason, let metadata)) = result else {
             return XCTFail("expected a .validation failure, got \(result)")
         }
         XCTAssertTrue(reason.contains("application/json"), "the reason should explain the expectation; got \(reason)")
@@ -41,7 +42,9 @@ final class ResponseValidatorIntegrationTests: XCTestCase {
 
         let result: Result<Data, NetworkingError> = await networking.get("/status/500")
 
-        guard case let .failure(.http(error)) = result else { return XCTFail("expected an .http failure, got \(result)") }
+        guard case .failure(.http(let error)) = result else {
+            return XCTFail("expected an .http failure, got \(result)")
+        }
         XCTAssertEqual(error.statusCode, 500)
     }
 
@@ -52,7 +55,7 @@ final class ResponseValidatorIntegrationTests: XCTestCase {
 
         // Prime the cache with no validator installed: /xml (200, application/xml) gets stored.
         let primed: Result<Data, NetworkingError> = await networking.get("/xml", cachingLevel: .memory)
-        if case let .failure(error) = primed { return XCTFail("priming the cache should succeed, got \(error)") }
+        if case .failure(let error) = primed { return XCTFail("priming the cache should succeed, got \(error)") }
 
         await requireJSON(networking)
         // Same request → a cache hit → must still run the JSON validator and be rejected.
@@ -69,6 +72,6 @@ final class ResponseValidatorIntegrationTests: XCTestCase {
 
         let result: Result<JSONResponse, NetworkingError> = await networking.get("/json")
 
-        if case let .failure(error) = result { XCTFail("expected the JSON response to pass validation, got \(error)") }
+        if case .failure(let error) = result { XCTFail("expected the JSON response to pass validation, got \(error)") }
     }
 }

--- a/Tests/NetworkingTests/RetryInterceptorTests.swift
+++ b/Tests/NetworkingTests/RetryInterceptorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 // Retry behavior is exercised with a scripted innermost interceptor that short-circuits (returns a canned
@@ -10,7 +11,10 @@ final class RetryInterceptorTests: XCTestCase {
 
     actor CallCounter {
         private(set) var count = 0
-        func tick() -> Int { count += 1; return count }
+        func tick() -> Int {
+            count += 1
+            return count
+        }
     }
 
     enum ScriptedOutcome: Sendable {
@@ -22,14 +26,16 @@ final class RetryInterceptorTests: XCTestCase {
         let counter: CallCounter
         let outcomeForAttempt: @Sendable (Int) -> ScriptedOutcome
 
-        func intercept(_ request: URLRequest, next: @Sendable (URLRequest) async throws -> HTTPExchange) async throws -> HTTPExchange {
+        func intercept(_ request: URLRequest, next: @Sendable (URLRequest) async throws -> HTTPExchange) async throws
+            -> HTTPExchange
+        {
             let attempt = await counter.tick()
             switch outcomeForAttempt(attempt) {
-            case let .status(code, headers):
+            case .status(let code, let headers):
                 let url = request.url ?? URL(string: "https://example.com")!
                 let response = HTTPURLResponse(url: url, statusCode: code, httpVersion: nil, headerFields: headers)!
                 return HTTPExchange(data: Data(), response: response)
-            case let .throwTransport(code):
+            case .throwTransport(let code):
                 throw URLError(code)
             }
         }
@@ -50,7 +56,7 @@ final class RetryInterceptorTests: XCTestCase {
 
         let result: Result<Data, NetworkingError> = await networking.get("/anything")
 
-        if case let .failure(error) = result { XCTFail("expected success after retries, got \(error)") }
+        if case .failure(let error) = result { XCTFail("expected success after retries, got \(error)") }
         let attempts = await counter.count
         XCTAssertEqual(attempts, 3, "two 503s should be retried, succeeding on the third attempt")
     }
@@ -64,7 +70,9 @@ final class RetryInterceptorTests: XCTestCase {
 
         let result: Result<Data, NetworkingError> = await networking.get("/anything")
 
-        guard case let .failure(.http(error)) = result else { return XCTFail("expected an HTTP failure, got \(result)") }
+        guard case .failure(.http(let error)) = result else {
+            return XCTFail("expected an HTTP failure, got \(result)")
+        }
         XCTAssertEqual(error.statusCode, 503)
         let attempts = await counter.count
         XCTAssertEqual(attempts, 3, "a persistently failing request should stop at maxAttempts")
@@ -74,7 +82,9 @@ final class RetryInterceptorTests: XCTestCase {
         let counter = CallCounter()
         let networking = await networking(
             RetryInterceptor(maxAttempts: 3, baseDelay: .milliseconds(1), maxDelay: .seconds(5)),
-            ScriptedInterceptor(counter: counter) { $0 == 1 ? .status(429, headers: ["Retry-After": "1"]) : .status(200) }
+            ScriptedInterceptor(counter: counter) {
+                $0 == 1 ? .status(429, headers: ["Retry-After": "1"]) : .status(200)
+            }
         )
 
         let clock = ContinuousClock()
@@ -82,8 +92,9 @@ final class RetryInterceptorTests: XCTestCase {
         let result: Result<Data, NetworkingError> = await networking.get("/anything")
         let elapsed = clock.now - start
 
-        if case let .failure(error) = result { XCTFail("expected success after honoring Retry-After, got \(error)") }
-        XCTAssertGreaterThanOrEqual(elapsed, .milliseconds(900), "Retry-After: 1 should pace the retry ~1s, not the 1ms base backoff")
+        if case .failure(let error) = result { XCTFail("expected success after honoring Retry-After, got \(error)") }
+        XCTAssertGreaterThanOrEqual(
+            elapsed, .milliseconds(900), "Retry-After: 1 should pace the retry ~1s, not the 1ms base backoff")
     }
 
     // Retrying a non-idempotent request after a timeout/5xx can duplicate a side effect (a second charge,
@@ -98,7 +109,9 @@ final class RetryInterceptorTests: XCTestCase {
 
         let result: Result<Data, NetworkingError> = await networking.post("/anything", body: ["k": "v"])
 
-        guard case let .failure(.http(error)) = result else { return XCTFail("expected an HTTP failure, got \(result)") }
+        guard case .failure(.http(let error)) = result else {
+            return XCTFail("expected an HTTP failure, got \(result)")
+        }
         XCTAssertEqual(error.statusCode, 503)
         let attempts = await counter.count
         XCTAssertEqual(attempts, 1, "POST is not idempotent and must not be retried by default")
@@ -107,8 +120,9 @@ final class RetryInterceptorTests: XCTestCase {
     func testRetriesNonIdempotentMethodWhenExplicitlyConfigured() async {
         let counter = CallCounter()
         let networking = await networking(
-            RetryInterceptor(maxAttempts: 3, baseDelay: .milliseconds(1), maxDelay: .milliseconds(2),
-                             retryableMethods: ["POST"]),
+            RetryInterceptor(
+                maxAttempts: 3, baseDelay: .milliseconds(1), maxDelay: .milliseconds(2),
+                retryableMethods: ["POST"]),
             ScriptedInterceptor(counter: counter) { _ in .status(503) }
         )
 
@@ -128,7 +142,9 @@ final class RetryInterceptorTests: XCTestCase {
 
         let result: Result<Data, NetworkingError> = await networking.get("/anything")
 
-        guard case let .failure(.http(error)) = result else { return XCTFail("expected an HTTP failure, got \(result)") }
+        guard case .failure(.http(let error)) = result else {
+            return XCTFail("expected an HTTP failure, got \(result)")
+        }
         XCTAssertEqual(error.statusCode, 404)
         let attempts = await counter.count
         XCTAssertEqual(attempts, 1, "a 404 is not retryable and must not be retried")
@@ -143,7 +159,9 @@ final class RetryInterceptorTests: XCTestCase {
 
         let result: Result<Data, NetworkingError> = await networking.get("/anything")
 
-        if case let .failure(error) = result { XCTFail("expected success after transient transport retries, got \(error)") }
+        if case .failure(let error) = result {
+            XCTFail("expected success after transient transport retries, got \(error)")
+        }
         let attempts = await counter.count
         XCTAssertEqual(attempts, 3, "two timeouts should be retried, succeeding on the third attempt")
     }

--- a/Tests/NetworkingTests/String+UTF8Tests.swift
+++ b/Tests/NetworkingTests/String+UTF8Tests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 class String_UTF8Tests: XCTestCase {

--- a/Tests/NetworkingTests/TestHelpers.swift
+++ b/Tests/NetworkingTests/TestHelpers.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 @testable import Networking
 
 extension AsyncStream {

--- a/Tests/NetworkingTests/TypedRequestBodyIntegrationTests.swift
+++ b/Tests/NetworkingTests/TypedRequestBodyIntegrationTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+
 @testable import Networking
 
 private struct Credentials: Codable, Equatable {
@@ -23,10 +24,10 @@ final class TypedRequestBodyIntegrationTests: XCTestCase {
         let body = Credentials(username: "jameson", age: 20, active: true)
         let result: Result<BodyEcho, NetworkingError> = await networking.post("/post", body: body)
         switch result {
-        case let .success(echo):
+        case .success(let echo):
             XCTAssertEqual(echo.json, body)
             XCTAssertEqual(echo.headers["Content-Type"]?.first, "application/json")
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -35,7 +36,7 @@ final class TypedRequestBodyIntegrationTests: XCTestCase {
         let networking = Networking(baseURL: baseURL)
         let body = Credentials(username: "jameson", age: 20, active: true)
         let result: Result<Void, NetworkingError> = await networking.post("/post", body: body)
-        if case let .failure(error) = result {
+        if case .failure(let error) = result {
             XCTFail(error.localizedDescription)
         }
     }
@@ -45,9 +46,9 @@ final class TypedRequestBodyIntegrationTests: XCTestCase {
         let body = Credentials(username: "ada", age: 36, active: false)
         let result: Result<BodyEcho, NetworkingError> = await networking.put("/put", body: body)
         switch result {
-        case let .success(echo):
+        case .success(let echo):
             XCTAssertEqual(echo.json, body)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }
@@ -57,9 +58,9 @@ final class TypedRequestBodyIntegrationTests: XCTestCase {
         let body = Credentials(username: "grace", age: 45, active: true)
         let result: Result<BodyEcho, NetworkingError> = await networking.patch("/patch", body: body)
         switch result {
-        case let .success(echo):
+        case .success(let echo):
             XCTAssertEqual(echo.json, body)
-        case let .failure(error):
+        case .failure(let error):
             XCTFail(error.localizedDescription)
         }
     }

--- a/scripts/check-doc-links.py
+++ b/scripts/check-doc-links.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Fail if any relative markdown link in the repo's docs points to a missing file.
+
+Checks internal `[text](relative/path)` links only; ignores http(s)/mailto/anchor links.
+Run from anywhere: `python3 scripts/check-doc-links.py`.
+"""
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(__file__).resolve().parent.parent
+markdown_files = [
+    p for p in root.rglob("*.md") if ".build" not in p.parts and ".git" not in p.parts
+]
+link_re = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+dead: list[str] = []
+for md in markdown_files:
+    for match in link_re.finditer(md.read_text(encoding="utf-8")):
+        target = match.group(1).strip()
+        if target.startswith(("http://", "https://", "#", "mailto:")):
+            continue
+        path = target.split("#", 1)[0]
+        if not path:
+            continue
+        if not (md.parent / path).resolve().exists():
+            dead.append(f"{md.relative_to(root)} -> {target}")
+
+if dead:
+    print("::error::Dead relative doc links found:")
+    print("\n".join(dead))
+    sys.exit(1)
+
+print(f"OK: no dead relative links across {len(markdown_files)} markdown files.")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# One-time local setup for a fresh clone. Safe to re-run.
+set -e
+
+repo_root=$(git rev-parse --show-toplevel)
+git -C "$repo_root" config core.hooksPath .githooks
+echo "setup: core.hooksPath -> .githooks (swift-format pre-commit hook enabled)"


### PR DESCRIPTION
Borrows the swift-format and CI tooling from SwiftSync and adapts it to this repo (single package, go-httpbin-backed tests).

## What's added
- **`.swift-format`** — shared config (120 cols, 4-space indentation).
- **pre-commit hook** (`.githooks/pre-commit`) that formats staged Swift files; enable once per clone with `./scripts/setup.sh`.
- **CI jobs** (`.github/workflows/ci.yml`):
  - `swift-format check` — `swift format --in-place --recursive Sources Tests` then `git diff --exit-code`.
  - `Warnings gate` — fresh `swift build --build-tests` (no cache), fails on any first-party `warning:`.
  - `Doc link check` — `scripts/check-doc-links.py` fails on dead relative markdown links.
  - existing build & test job (against local go-httpbin) retained.
- **Reformat** of `Sources/` and `Tests/` to satisfy the format check.

## Verified locally
- `swift format --in-place --recursive Sources Tests` is idempotent (format check passes).
- `swift build --build-tests` clean, no first-party warnings.
- `scripts/check-doc-links.py`: OK across 10 markdown files.
- Offline/fake suites pass.

The perf-regression gate from SwiftSync was intentionally dropped — this repo has no benchmark suite.